### PR TITLE
Add TPE gamma-sensitivity ablation against parameter-free BASS-BO/GP-BO

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ Rscript code_files/run_benchmark.R --objective=branin --d=2 --budget=80 --reps=2
 Rscript code_files/run_benchmark.R --objective=rastrigin --d=4 --reps=10
 
 # The hand-built non-smooth surface (any dimension)
-Rscript code_files/run_benchmark.R --objective=synthetic --d=3 --out_dir=results_syn
+Rscript code_files/run_benchmark.R --objective=synthetic --d=3
 
 # Use the fast single-draw Thompson-sampling acquisition for BASS instead of EI
 Rscript code_files/run_benchmark.R --objective=branin --acquisition=thompson
 
 # Categorical / mixed benchmarks, with the categorical-capable TPE baseline added
 # (needs reticulate + optuna; see RUNNING.md §1)
-Rscript code_files/run_benchmark.R --objective=func2C --with_tpe=true --out_dir=results_func2C
-Rscript code_files/run_benchmark.R --objective=cat_ackley --d=6 --with_tpe=true --out_dir=results_catackley
+Rscript code_files/run_benchmark.R --objective=func2C --with_tpe=true
+Rscript code_files/run_benchmark.R --objective=cat_ackley --d=6 --with_tpe=true
 ```
 
 A separate ablation, `code_files/2_tpe_sensitivity/run_tpe_sensitivity.R`,

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ where $h_m(X)$ represents a basis function or a product of hinge functions.
 │   ├── run_benchmark.R      # Single entry point for the synthetic benchmarks
 │   ├── tests/               # testthat unit-test suite for the library
 │   ├── 1_base_loop/         # Exploratory R Markdown notebooks (pedagogical)
+│   ├── 2_tpe_sensitivity/   # Ablation: TPE's gamma sensitivity vs. parameter-free BASS-BO/GP-BO
+│   │   └── run_tpe_sensitivity.R #   driver (reuses the shared library)
 │   ├── 4_regression_test_case/ # Real-world case study: Elastic Net tuning
 │   │   ├── run_elastic_net.R   #   driver (reuses the shared library)
 │   │   └── enet_objective.R    #   CV-RMSE objective over (alpha, lambda)
@@ -91,6 +93,14 @@ Rscript code_files/run_benchmark.R --objective=branin --acquisition=thompson
 # (needs reticulate + optuna; see RUNNING.md §1)
 Rscript code_files/run_benchmark.R --objective=func2C --with_tpe=true --out_dir=results_func2C
 Rscript code_files/run_benchmark.R --objective=cat_ackley --d=6 --with_tpe=true --out_dir=results_catackley
+```
+
+A separate ablation, `code_files/2_tpe_sensitivity/run_tpe_sensitivity.R`,
+sweeps TPE's `gamma` hyperparameter and compares the spread against the
+parameter-free BASS-BO/GP-BO baselines (see that directory's `README.md`):
+
+```bash
+Rscript code_files/2_tpe_sensitivity/run_tpe_sensitivity.R
 ```
 
 The real-world Elastic Net case study uses the **same** optimisers via a small

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -72,6 +72,8 @@ code_files/
     objectives/            #   branin, rastrigin, synthetic, categorical, + loader
   run_benchmark.R          # entry point for the synthetic benchmarks
   tests/                   # testthat unit tests
+  2_tpe_sensitivity/
+    run_tpe_sensitivity.R  # entry point for the TPE gamma-sensitivity ablation
   4_regression_test_case/
     run_elastic_net.R      # entry point for the Elastic Net case study
     enet_objective.R       #   the CV-RMSE objective (alpha, lambda)
@@ -101,6 +103,8 @@ This runs all `testthat` tests under `code_files/tests/testthat/`:
   run on a categorical objective.
 - **`test-tpe.R`** — the TPE baseline against `run_bo()`'s contract on a continuous
   and a categorical objective (self-skips unless `reticulate` + `optuna` are present).
+- **`test-tpe-sensitivity.R`** — `run_tpe()`'s `sampler_opts` argument and
+  `run_tpe_sweep_experiment()` (same self-skip behaviour).
 
 Notes:
 - The BASS/GP and TPE end-to-end tests self-skip if their dependencies aren't
@@ -142,7 +146,7 @@ Every key in `default_config()` (`code_files/R/config.R`) is settable as
 | `--reps` | `10` | independent repetitions (seeds) |
 | `--seed_start` | `1001` | first seed (`reps` use `seed_start + 0..reps-1`) |
 | `--out_dir` | `results` | output folder |
-| `--acquisition` | `ei` | BASS acquisition: `ei` or `thompson` (see §6) |
+| `--acquisition` | `ei` | BASS acquisition: `ei` or `thompson` (see §7) |
 | `--with_tpe` | `false` | add the TPE (Optuna) baseline; needs `reticulate`+`optuna` (§1) |
 
 The categorical/mixed objectives (`func2C`, `func3C`, `cat_ackley`) and the
@@ -156,7 +160,34 @@ Rscript code_files/run_benchmark.R --objective=cat_ackley --d=6 --with_tpe=true 
 
 ---
 
-## 5. Run the Elastic Net case study
+## 5. Run the TPE sensitivity ablation
+
+BASS-BO and GP-BO are parameter-free (no exploration weight, no candidate-
+generator knob to tune); TPE is not. This script tests the thesis's claim
+that TPE has essentially one hyperparameter worth tuning, `gamma`, by
+sweeping it across `{0.10, 0.25, 0.50, 0.75}` on one continuous benchmark
+(Branin) and one purely categorical one (Cat-Ackley), and plotting the
+spread next to the fixed BASS-BO/GP-BO/Random curves. It needs the same
+`reticulate`+`optuna` setup as `--with_tpe` above (§1), and aborts up front
+if that's unavailable.
+
+```bash
+# Default protocol: budget=80, reps=25, seed_start=1001 (matches §4)
+Rscript code_files/2_tpe_sensitivity/run_tpe_sensitivity.R
+
+# Faster, smaller sweep for a quick check
+Rscript code_files/2_tpe_sensitivity/run_tpe_sensitivity.R --budget=40 --reps=10
+```
+
+Writes `results_tpe_sensitivity/branin/` and
+`results_tpe_sensitivity/cat_ackley/` (CSVs + convergence plot each, via the
+same `save_results()` used by §4), plus a printed "TPE final-best range
+across gamma" line quantifying the spread. See
+`code_files/2_tpe_sensitivity/README.md` for details.
+
+---
+
+## 6. Run the Elastic Net case study
 
 Tunes an Elastic Net (`alpha`, `lambda`) on the Boston Housing data by minimising
 cross-validated RMSE, then evaluates the chosen model on a held-out test set.
@@ -178,7 +209,7 @@ Extra flags (on top of the shared ones above):
 
 ---
 
-## 6. Acquisition: `ei` vs `thompson`
+## 7. Acquisition: `ei` vs `thompson`
 
 Both surrogates are scored with **Expected Improvement** — closed-form for the
 GP, and Monte Carlo (straight from the posterior draws) for BASS. This is
@@ -195,7 +226,7 @@ BASS-BO and GP-BO is the surrogate model.
 
 ---
 
-## 7. Outputs
+## 8. Outputs
 
 Each synthetic run writes to `--out_dir` (default `results/`):
 
@@ -215,7 +246,7 @@ The Elastic Net run additionally writes `final_summary_cv.csv`,
 
 ---
 
-## 8. Adding a new objective
+## 9. Adding a new objective
 
 1. Add the function (and, if it lives on a physical domain, its `*_bounds`) to
    `code_files/R/objectives/`. Benchmarks on a physical domain are wrapped with
@@ -226,7 +257,7 @@ Nothing in the BO loop needs to change — `run_bo()` is objective-agnostic.
 
 ---
 
-## 9. Performance & troubleshooting
+## 10. Performance & troubleshooting
 
 - **Parallelism.** Runs fan out across seeds using `future`/`furrr`, using
   `cores - 1` workers. Lower `--reps` (or the worker count via the `future` plan

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -125,8 +125,8 @@ Rscript code_files/run_benchmark.R --objective=branin --d=2 --budget=80 --reps=2
 # Rastrigin (4-D)
 Rscript code_files/run_benchmark.R --objective=rastrigin --d=4 --reps=10
 
-# The hand-built non-smooth surface (any dimension), custom output folder
-Rscript code_files/run_benchmark.R --objective=synthetic --d=3 --out_dir=results_syn
+# The hand-built non-smooth surface (any dimension)
+Rscript code_files/run_benchmark.R --objective=synthetic --d=3
 
 # Quick smoke run while iterating
 Rscript code_files/run_benchmark.R --objective=branin --budget=15 --reps=3
@@ -145,7 +145,7 @@ Every key in `default_config()` (`code_files/R/config.R`) is settable as
 | `--n_cand` | `1000` | candidate points scored per iteration |
 | `--reps` | `10` | independent repetitions (seeds) |
 | `--seed_start` | `1001` | first seed (`reps` use `seed_start + 0..reps-1`) |
-| `--out_dir` | `results` | output folder |
+| `--out_dir` | `results` | results root; each run nests a per-objective subfolder under it |
 | `--acquisition` | `ei` | BASS acquisition: `ei` or `thompson` (see §7) |
 | `--with_tpe` | `false` | add the TPE (Optuna) baseline; needs `reticulate`+`optuna` (§1) |
 
@@ -154,8 +154,8 @@ The categorical/mixed objectives (`func2C`, `func3C`, `cat_ackley`) and the
 natively, so it is the strongest comparison there:
 
 ```bash
-Rscript code_files/run_benchmark.R --objective=func2C --with_tpe=true --out_dir=results_func2C
-Rscript code_files/run_benchmark.R --objective=cat_ackley --d=6 --with_tpe=true --out_dir=results_catackley
+Rscript code_files/run_benchmark.R --objective=func2C --with_tpe=true
+Rscript code_files/run_benchmark.R --objective=cat_ackley --d=6 --with_tpe=true
 ```
 
 ---
@@ -179,8 +179,8 @@ Rscript code_files/2_tpe_sensitivity/run_tpe_sensitivity.R
 Rscript code_files/2_tpe_sensitivity/run_tpe_sensitivity.R --budget=40 --reps=10
 ```
 
-Writes `results_tpe_sensitivity/branin/` and
-`results_tpe_sensitivity/cat_ackley/` (CSVs + convergence plot each, via the
+Writes `results/tpe_sensitivity/branin/` and
+`results/tpe_sensitivity/cat_ackley/` (CSVs + convergence plot each, via the
 same `save_results()` used by §4), plus a printed "TPE final-best range
 across gamma" line quantifying the spread. See
 `code_files/2_tpe_sensitivity/README.md` for details.
@@ -228,7 +228,16 @@ BASS-BO and GP-BO is the surrogate model.
 
 ## 8. Outputs
 
-Each synthetic run writes to `--out_dir` (default `results/`):
+Every runner writes under a single `results/` root, each in its own subfolder, so
+nothing overwrites anything else:
+
+| Runner | Output location |
+|---|---|
+| `run_benchmark.R` | `results/<objective>/` (e.g. `results/branin/`, `results/cat_ackley/`) |
+| `2_tpe_sensitivity/run_tpe_sensitivity.R` | `results/tpe_sensitivity/<objective>/` |
+| `4_regression_test_case/run_elastic_net.R` | `results/elastic_net/` |
+
+Each synthetic run writes:
 
 | File | Contents |
 |---|---|

--- a/code_files/2_tpe_sensitivity/README.md
+++ b/code_files/2_tpe_sensitivity/README.md
@@ -32,8 +32,8 @@ if TPE is unavailable, since there is nothing else for it to do.
 
 ## Output
 
-Writes `results_tpe_sensitivity/branin/` and
-`results_tpe_sensitivity/cat_ackley/`, each with the usual
+Writes `results/tpe_sensitivity/branin/` and
+`results/tpe_sensitivity/cat_ackley/`, each with the usual
 `all_runs.csv`, `summary_curve.csv`, `final_summary.csv`, and
 `convergence_mean_ci.png` (via the shared `save_results()`), plus a
 printed "TPE final-best range across gamma" spread -- the number that

--- a/code_files/2_tpe_sensitivity/README.md
+++ b/code_files/2_tpe_sensitivity/README.md
@@ -1,0 +1,44 @@
+# TPE hyperparameter sensitivity
+
+BASS-BO and GP-BO are parameter-free: there is no exploration weight, no
+kappa, no candidate-generator setting to tune (see `R/config.R` and
+Experiment.tex, "Acquisition and Candidate Generation"). TPE is not --
+Optuna's `TPESampler` exposes several sampler hyperparameters, and the
+thesis (`Surrogate_Models.tex`) singles out `gamma`, the quantile of trials
+treated as "good," as the one that matters. This experiment makes that claim
+testable: it sweeps `gamma` over `{0.10, 0.25, 0.50, 0.75}` and plots the
+resulting TPE curves next to the single, un-sweepable BASS-BO/GP-BO/Random
+curves, on one continuous benchmark (Branin, 2D) and one purely categorical
+one (Cat-Ackley, 6D) -- the two regimes TPE is compared against BASS-BO on
+elsewhere in the suite.
+
+TPE has no MCMC fit per iteration, so the whole sweep (4 gamma values x 2
+objectives x `reps` seeds) is cheap relative to the main benchmark suite.
+
+## Running
+
+```bash
+# Default protocol: budget=80, reps=25, seed_start=1001 (matches the main
+# benchmark suite for a direct comparison)
+Rscript code_files/2_tpe_sensitivity/run_tpe_sensitivity.R
+
+# Faster, smaller sweep for a quick check
+Rscript code_files/2_tpe_sensitivity/run_tpe_sensitivity.R --budget=40 --reps=10
+```
+
+Needs `reticulate` + an importable `optuna` Python module, same as the
+`--with_tpe` baseline (see `RUNNING.md` Sec. 1); the script aborts up front
+if TPE is unavailable, since there is nothing else for it to do.
+
+## Output
+
+Writes `results_tpe_sensitivity/branin/` and
+`results_tpe_sensitivity/cat_ackley/`, each with the usual
+`all_runs.csv`, `summary_curve.csv`, `final_summary.csv`, and
+`convergence_mean_ci.png` (via the shared `save_results()`), plus a
+printed "TPE final-best range across gamma" spread -- the number that
+quantifies how much gamma moves TPE's outcome, in contrast to the fixed
+BASS-BO/GP-BO baselines.
+
+This result feeds the "TPE Hyperparameter Sensitivity" subsection in
+`written_files/tesis_escrito/TeX_files/Experiment.tex`.

--- a/code_files/2_tpe_sensitivity/run_tpe_sensitivity.R
+++ b/code_files/2_tpe_sensitivity/run_tpe_sensitivity.R
@@ -1,0 +1,127 @@
+#!/usr/bin/env Rscript
+
+# =============================================================================
+# run_tpe_sensitivity.R  --  Is TPE's "no tuning needed" claim actually true?
+# =============================================================================
+# BASS-BO and GP-BO are parameter-free by construction (see R/config.R and
+# the "Acquisition and Candidate Generation" section of Experiment.tex): there
+# is no exploration weight, no kappa, no candidate-generator knob to set.
+# TPE is not -- Optuna's TPESampler exposes
+# several sampler-level hyperparameters, and the thesis (Surrogate_Models.tex)
+# singles out one in particular: gamma, the quantile of trials treated as
+# "good" versus "bad". This script tests that claim empirically: it sweeps
+# gamma across a small grid and plots the resulting TPE curves alongside the
+# (un-sweepable, single-curve) BASS-BO and GP-BO references, on one continuous
+# benchmark (Branin) and one purely categorical one (Cat-Ackley) -- the two
+# regimes TPE is pitched against BASS-BO on.
+#
+# TPE is cheap (no MCMC fit per iteration), so the whole sweep -- four gamma
+# values x two objectives x reps seeds -- is inexpensive relative to the main
+# benchmark suite.
+#
+# Example:
+#   Rscript code_files/2_tpe_sensitivity/run_tpe_sensitivity.R
+#   Rscript code_files/2_tpe_sensitivity/run_tpe_sensitivity.R --budget=40 --reps=10
+# =============================================================================
+
+suppressPackageStartupMessages({
+  library(tidyverse)
+  library(lhs)
+  library(BASS)
+  library(GPfit)
+  library(future)
+  library(furrr)
+})
+
+# --- Load the shared BO library, relative to this script's location ----------
+this_file  <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+script_dir <- if (length(this_file)) dirname(normalizePath(this_file)) else getwd()
+lib_dir    <- normalizePath(file.path(script_dir, "..", "R"))
+
+source(file.path(lib_dir, "bootstrap.R"))
+source_library(lib_dir)
+
+if (!tpe_available()) {
+  stop("This experiment needs `reticulate` + an importable `optuna`. ",
+       "See RUNNING.md for setup; nothing to do without TPE.")
+}
+
+# --- Configuration -------------------------------------------------------------
+# Same protocol as the main benchmark suite (matched budget/reps/seed_start),
+# so this sensitivity result is directly comparable to Experiment.tex's
+# headline figures. Overridable the same way: --key=value.
+sensitivity_default_config <- function() {
+  cfg <- default_config()
+  cfg$budget     <- 80
+  cfg$reps       <- 25
+  cfg$seed_start <- 1001L
+  cfg$out_dir    <- "results_tpe_sensitivity"
+  cfg
+}
+cfg_base <- parse_cli_args(commandArgs(trailingOnly = TRUE), sensitivity_default_config())
+
+plan(multisession, workers = max(1L, parallel::detectCores() - 1L))
+
+# --- The gamma grid -------------------------------------------------------------
+# gamma(n) returns the number of "good" trials out of n completed ones; a
+# quantile-based callable is the simplest way to vary it. 0.25 sits close to
+# Optuna's own default behaviour, giving a built-in sanity check.
+gamma_quantile <- function(q) function(n) as.integer(ceiling(q * max(n, 1)))
+gamma_grid     <- c(0.10, 0.25, 0.50, 0.75)
+
+make_configs <- function() {
+  configs <- lapply(gamma_grid, function(q) {
+    list(sampler_opts = list(gamma = gamma_quantile(q)))
+  })
+  names(configs) <- sprintf("TPE (gamma=%.2f)", gamma_grid)
+  configs
+}
+
+# --- One objective: reference curves (BASS-BO/GP-BO/Random) + the gamma sweep -
+run_one_objective <- function(cfg) {
+  objective <- load_objective(cfg$objective, cfg$d)
+  cat(sprintf("\n== %s (d=%d) | budget=%d | reps=%d ==\n",
+              cfg$objective, objective$d, cfg$budget, cfg$reps))
+
+  cat("Running BASS-BO / GP-BO / Random reference curves ...\n")
+  reference_runs <- run_experiment(cfg)
+
+  cat("Running TPE gamma sweep ...\n")
+  sweep_runs <- run_tpe_sweep_experiment(cfg, make_configs())
+
+  all_runs <- dplyr::bind_rows(reference_runs, sweep_runs)
+  final_summary <- save_results(all_runs, objective, cfg)
+
+  # Rank-volatility check: how much does TPE's final performance move across
+  # gamma, relative to the fixed (single-curve) BASS-BO/GP-BO baselines?
+  cat("\nFinal best-so-far by method (sorted):\n")
+  print(final_summary)
+
+  tpe_rows <- dplyr::filter(final_summary, grepl("^TPE", method))
+  cat(sprintf(
+    "\nTPE final-best range across gamma: [%.4f, %.4f] (spread = %.4f)\n",
+    min(tpe_rows$mean_final), max(tpe_rows$mean_final),
+    max(tpe_rows$mean_final) - min(tpe_rows$mean_final)
+  ))
+
+  final_summary
+}
+
+# --- Run on one continuous and one categorical benchmark ----------------------
+cfg_branin <- cfg_base
+cfg_branin$objective <- "branin"
+cfg_branin$d         <- 2
+cfg_branin$out_dir   <- file.path(cfg_base$out_dir, "branin")
+
+cfg_catackley <- cfg_base
+cfg_catackley$objective <- "cat_ackley"
+cfg_catackley$d         <- 6
+cfg_catackley$out_dir   <- file.path(cfg_base$out_dir, "cat_ackley")
+
+run_one_objective(cfg_branin)
+run_one_objective(cfg_catackley)
+
+cat(sprintf("\nArtifacts saved under: %s\n", normalizePath(cfg_base$out_dir)))
+
+# --- Shut down parallel workers so the process can exit -----------------------
+plan(sequential)

--- a/code_files/2_tpe_sensitivity/run_tpe_sensitivity.R
+++ b/code_files/2_tpe_sensitivity/run_tpe_sensitivity.R
@@ -55,7 +55,7 @@ sensitivity_default_config <- function() {
   cfg$budget     <- 80
   cfg$reps       <- 25
   cfg$seed_start <- 1001L
-  cfg$out_dir    <- "results_tpe_sensitivity"
+  cfg$out_dir    <- file.path("results", "tpe_sensitivity")
   cfg
 }
 cfg_base <- parse_cli_args(commandArgs(trailingOnly = TRUE), sensitivity_default_config())

--- a/code_files/4_regression_test_case/run_elastic_net.R
+++ b/code_files/4_regression_test_case/run_elastic_net.R
@@ -45,7 +45,7 @@ enet_default_config <- function() {
   cfg$budget    <- 100
   cfg$n_cand    <- 1500
   cfg$reps      <- 50
-  cfg$out_dir   <- "results_enet_bo"
+  cfg$out_dir   <- file.path("results", "elastic_net")
   cfg$train_frac        <- 0.8
   cfg$nfolds            <- 5L
   cfg$lambda_log10_min  <- -5

--- a/code_files/R/config.R
+++ b/code_files/R/config.R
@@ -22,7 +22,7 @@ default_config <- function() {
     n_cand     = 1000,      # candidate points scored per iteration
     reps       = 10,        # independent repetitions (seeds)
     seed_start = 1001,      # first seed; reps use seed_start + 0..reps-1
-    out_dir    = "results", # where CSVs and the plot are written
+    out_dir    = "results", # results root; runners nest a per-objective subfolder
 
     # ---- Acquisition ----
     # BASS acquisition: "ei" (Monte Carlo Expected Improvement, the principled

--- a/code_files/R/surrogates.R
+++ b/code_files/R/surrogates.R
@@ -21,6 +21,48 @@ BASS_NBURN <- 2000L
 BASS_THIN  <- 10L
 BASS_KEEP  <- (BASS_NMCMC - BASS_NBURN) %/% BASS_THIN   # 200 stored draws
 
+#' Work around a BASS bug that crashes prediction on purely categorical models.
+#'
+#' For a categorical model the RJMCMC posterior routinely contains intercept-only
+#' draws (nbasis == 0) -- especially early in the BO loop, before BASS has fit any
+#' categorical basis. BASS's continuous basis-matrix builder guards that case
+#' (`if (nbasis > 0)`), but its categorical counterpart, makeBasisMatrixCat(),
+#' does not: it runs `for (m in 1:nbasis)`, and in R `1:0` is `c(1, 0)`, so it
+#' reads `n.int.cat[i, 1]` -- NA for a zero-basis model -- and dies with
+#' "missing value where TRUE/FALSE needed". Cat-Ackley triggers this reliably.
+#'
+#' We install a guarded copy of makeBasisMatrixCat into BASS's namespace. The only
+#' change is wrapping the loop in `if (nbasis > 0)`, exactly as the continuous
+#' builder does; zero-basis draws then correctly predict the intercept. The fix is
+#' idempotent, runs once per R session (so it also fires on each furrr worker, via
+#' the call in make_bass_acquire's closure), and becomes a no-op if a future BASS
+#' ships the guard itself.
+.ensure_bass_cat_predict_fix <- function() {
+  if (isTRUE(getOption("bass_cat_predict_fixed"))) return(invisible())
+
+  patched <- function(i, nbasis, vars, xx, n.int, sub) {
+    n <- nrow(xx)
+    tbasis.mat <- matrix(nrow = nbasis + 1, ncol = n)
+    tbasis.mat[1, ] <- 1
+    if (nbasis > 0) {
+      for (m in 1:nbasis) {
+        if (n.int[i, m] == 0) {
+          tbasis.mat[m + 1, ] <- 1
+        } else {
+          use <- 1:n.int[i, m]
+          tbasis.mat[m + 1, ] <- makeBasisCat(vars[i, m, use], sub[[i]][[m]], xx)
+        }
+      }
+    }
+    tbasis.mat
+  }
+  # Resolve BASS's unqualified internals (e.g. makeBasisCat) from its namespace.
+  environment(patched) <- asNamespace("BASS")
+  utils::assignInNamespace("makeBasisMatrixCat", patched, ns = "BASS")
+  options(bass_cat_predict_fixed = TRUE)
+  invisible()
+}
+
 #' Orient a predict.bass() matrix to rows = samples, columns = candidates.
 #'
 #' predict.bass can return either orientation; we know the candidate count, so
@@ -50,6 +92,10 @@ BASS_KEEP  <- (BASS_NMCMC - BASS_NBURN) %/% BASS_THIN   # 200 stored draws
 #' @return An `acquire(X_eval, y_eval, X_cand)` function (captures `cfg`, `schema`).
 make_bass_acquire <- function(cfg, schema = NULL) {
   function(X_eval, y_eval, X_cand) {
+    # Guard BASS's categorical predict path (no-op once applied; see above). Done
+    # here, inside the exported closure, so it also runs on each furrr worker.
+    if (!is.null(schema)) .ensure_bass_cat_predict_fix()
+
     X_eval <- as.matrix(X_eval)
     n_cand <- nrow(as.matrix(X_cand))
 

--- a/code_files/R/tpe.R
+++ b/code_files/R/tpe.R
@@ -49,13 +49,16 @@ tpe_available <- function() {
 #' is suggested as one of its levels, then mapped back to the representative
 #' unit-cube coordinate that `objective$fn` decodes to that level.
 #'
-#' @param objective Objective list (`fn`, `d`, and optional `schema`).
-#' @param cfg       Config list (uses `budget`).
-#' @param X_init    Initial design (matrix in [0, 1]^d), shared with the others.
-#' @param y_init    Objective values at `X_init`.
-#' @param seed      Integer seed for the TPE sampler (reproducibility).
+#' @param objective    Objective list (`fn`, `d`, and optional `schema`).
+#' @param cfg          Config list (uses `budget`).
+#' @param X_init       Initial design (matrix in [0, 1]^d), shared with the others.
+#' @param y_init       Objective values at `X_init`.
+#' @param seed         Integer seed for the TPE sampler (reproducibility).
+#' @param sampler_opts Named list of extra arguments forwarded to
+#'   `optuna$samplers$TPESampler()` (e.g. `gamma`, `n_startup_trials`). Default
+#'   `list()` reproduces Optuna's own defaults, i.e. today's behaviour.
 #' @return A list with `best`: the best-so-far curve (length `budget + 1`).
-run_tpe <- function(objective, cfg, X_init, y_init, seed) {
+run_tpe <- function(objective, cfg, X_init, y_init, seed, sampler_opts = list()) {
   optuna <- reticulate::import("optuna", delay_load = FALSE)
   optuna$logging$set_verbosity(optuna$logging$WARNING)   # quiet the study logs
 
@@ -87,7 +90,8 @@ run_tpe <- function(objective, cfg, X_init, y_init, seed) {
     matrix(u, nrow = 1)
   }
 
-  sampler <- optuna$samplers$TPESampler(seed = as.integer(seed))
+  sampler <- do.call(optuna$samplers$TPESampler,
+                      c(list(seed = as.integer(seed)), sampler_opts))
   study   <- optuna$create_study(direction = "minimize", sampler = sampler)
 
   # Seed the study with the shared initial design as completed trials, so TPE
@@ -156,6 +160,47 @@ run_tpe_experiment <- function(cfg) {
       method = "TPE",
       best   = run_tpe(objective, cfg, X_init, y_init, seed)$best
     )
+  })
+  dplyr::bind_rows(curves)
+}
+
+#' Run TPE across all seeds for several sampler configurations.
+#'
+#' Companion to `run_tpe_experiment()` for a hyperparameter-sensitivity sweep:
+#' instead of one TPE curve per seed, this produces one curve per
+#' (seed, config) pair, with each config's `method` label distinguishing it in
+#' the resulting long tibble. Every config sees the SAME initial design per
+#' seed (same `set.seed(seed)` + maximin LHS), so the only thing that varies
+#' across curves for a fixed seed is the sampler configuration.
+#'
+#' @param cfg     Config list (uses `objective`, `d`, `budget`, `reps`,
+#'   `seed_start`), same as `run_tpe_experiment()`.
+#' @param configs Named list; each element is a list with a `sampler_opts`
+#'   entry (forwarded to `run_tpe()`). Names are used as the `method` label.
+#' @return Long tibble with columns seed, iter, method (one of `names(configs)`),
+#'   best.
+run_tpe_sweep_experiment <- function(cfg, configs) {
+  objective <- load_objective(cfg$objective, cfg$d)
+  d  <- objective$d
+  n0 <- max(2 * d + 1, 8)
+  seeds <- cfg$seed_start + 0:(cfg$reps - 1)
+
+  curves <- lapply(seeds, function(seed) {
+    set.seed(seed)
+    X_init <- lhs::maximinLHS(n0, d)
+    y_init <- objective$fn(X_init)
+
+    per_config <- lapply(names(configs), function(label) {
+      sampler_opts <- configs[[label]]$sampler_opts
+      tibble::tibble(
+        seed   = seed,
+        iter   = 0:cfg$budget,
+        method = label,
+        best   = run_tpe(objective, cfg, X_init, y_init, seed,
+                          sampler_opts = sampler_opts)$best
+      )
+    })
+    dplyr::bind_rows(per_config)
   })
   dplyr::bind_rows(curves)
 }

--- a/code_files/run_benchmark.R
+++ b/code_files/run_benchmark.R
@@ -8,14 +8,18 @@
 # plot. Everything is configurable from the command line; see default_config()
 # in R/config.R for the full list of --key=value flags.
 #
+# Each run writes into a per-objective subfolder of the results root, e.g.
+# results/branin/, results/cat_ackley/, so running different objectives no longer
+# overwrites one another. `--out_dir` sets the root (default "results").
+#
 # Examples:
 #   Rscript code_files/run_benchmark.R --objective=branin --d=2 --budget=80 --reps=25
 #   Rscript code_files/run_benchmark.R --objective=rastrigin --d=4 --reps=5
-#   Rscript code_files/run_benchmark.R --objective=synthetic --d=3 --out_dir=results_syn
+#   Rscript code_files/run_benchmark.R --objective=synthetic --d=3
 #   # Categorical / mixed benchmarks (d is fixed for func2C/func3C):
-#   Rscript code_files/run_benchmark.R --objective=func2C --budget=60 --out_dir=results_func2C
-#   Rscript code_files/run_benchmark.R --objective=func3C --budget=80 --out_dir=results_func3C
-#   Rscript code_files/run_benchmark.R --objective=cat_ackley --d=6 --out_dir=results_catackley
+#   Rscript code_files/run_benchmark.R --objective=func2C --budget=60
+#   Rscript code_files/run_benchmark.R --objective=func3C --budget=80
+#   Rscript code_files/run_benchmark.R --objective=cat_ackley --d=6
 #   # Add the TPE (Optuna) baseline (needs reticulate + an importable optuna):
 #   Rscript code_files/run_benchmark.R --objective=func2C --with_tpe=true
 # =============================================================================
@@ -41,6 +45,10 @@ source_library(lib_dir)
 
 # --- Configuration ------------------------------------------------------------
 cfg <- parse_cli_args(commandArgs(trailingOnly = TRUE))
+
+# Keep the results root tidy: give every objective its own subfolder, so runs on
+# different objectives accumulate side by side instead of overwriting each other.
+cfg$out_dir <- file.path(cfg$out_dir, cfg$objective)
 
 # --- Parallel backend: one worker per core, leaving one free -----------------
 plan(multisession, workers = max(1L, parallel::detectCores() - 1L))

--- a/code_files/tests/testthat/test-tpe-sensitivity.R
+++ b/code_files/tests/testthat/test-tpe-sensitivity.R
@@ -1,0 +1,69 @@
+# Tests for the TPE hyperparameter-sensitivity sweep (R/tpe.R: run_tpe()'s
+# `sampler_opts` argument and run_tpe_sweep_experiment()). They are skipped
+# entirely unless `reticulate` and an importable `optuna` are present, exactly
+# like test-tpe.R.
+
+test_that("run_tpe still matches run_bo's contract when sampler_opts is passed", {
+  skip_if_not(tpe_available(), "reticulate/optuna not available")
+
+  obj <- load_objective("branin", 2)
+  set.seed(1001)
+  X_init <- lhs::maximinLHS(2 * obj$d + 1, obj$d)
+  y_init <- obj$fn(X_init)
+  cfg    <- list(budget = 10)
+
+  gamma_q <- function(q) function(n) as.integer(ceiling(q * n))
+  res <- run_tpe(obj, cfg, X_init, y_init, seed = 1001,
+                 sampler_opts = list(gamma = gamma_q(0.25)))
+
+  expect_length(res$best, cfg$budget + 1)
+  expect_equal(res$best[1], min(y_init))
+  expect_true(all(diff(res$best) <= 1e-9))
+  expect_true(all(is.finite(res$best)))
+})
+
+test_that("different gamma quantiles are actually wired through to Optuna", {
+  skip_if_not(tpe_available(), "reticulate/optuna not available")
+
+  obj <- load_objective("branin", 2)
+  set.seed(3003)
+  X_init <- lhs::maximinLHS(2 * obj$d + 1, obj$d)
+  y_init <- obj$fn(X_init)
+  cfg    <- list(budget = 15)
+
+  gamma_q <- function(q) function(n) as.integer(ceiling(q * n))
+  a <- run_tpe(obj, cfg, X_init, y_init, seed = 7,
+               sampler_opts = list(gamma = gamma_q(0.10)))$best
+  b <- run_tpe(obj, cfg, X_init, y_init, seed = 7,
+               sampler_opts = list(gamma = gamma_q(0.75)))$best
+
+  expect_length(a, cfg$budget + 1)
+  expect_length(b, cfg$budget + 1)
+  expect_true(all(is.finite(a)) && all(is.finite(b)))
+  # Not asserting a < b or vice versa -- only that gamma is not silently
+  # ignored, i.e. the two configs need not produce identical curves.
+  expect_false(identical(a, b))
+})
+
+test_that("run_tpe_sweep_experiment stacks one labeled curve per (seed, config)", {
+  skip_if_not(tpe_available(), "reticulate/optuna not available")
+
+  cfg <- default_config()
+  cfg$objective <- "func2C"
+  cfg$d         <- 4
+  cfg$budget    <- 5
+  cfg$reps      <- 2
+
+  gamma_q <- function(q) function(n) as.integer(ceiling(q * n))
+  configs <- list(
+    "TPE (gamma=0.10)" = list(sampler_opts = list(gamma = gamma_q(0.10))),
+    "TPE (gamma=0.50)" = list(sampler_opts = list(gamma = gamma_q(0.50)))
+  )
+
+  runs <- run_tpe_sweep_experiment(cfg, configs)
+
+  expect_setequal(unique(runs$method), names(configs))
+  expect_equal(nrow(runs), cfg$reps * (cfg$budget + 1) * length(configs))
+  expect_setequal(unique(runs$seed), cfg$seed_start + 0:(cfg$reps - 1))
+  expect_true(all(is.finite(runs$best)))
+})

--- a/written_files/tesis_escrito/TeX_files/Experiment.tex
+++ b/written_files/tesis_escrito/TeX_files/Experiment.tex
@@ -86,6 +86,11 @@ Because the acquisition is maximized over a finite pool rather than by continuou
 
 The remaining settings are experimental hygiene rather than tuning knobs: \texttt{n\_cand}, the size of the candidate pool scored per iteration; \texttt{eps}, a small jitter added to the GP predictive variance for numerical stability; and \texttt{dup\_tol}, the distance below which two points are treated as duplicates and excluded from re-evaluation. Internally, the BASS surrogate is fit with a reduced RJMCMC budget relative to the package default, trading a little posterior resolution for speed inside the optimization loop; these are numerical settings of the sampler, not controls over the optimizer's behavior. The upshot is that the comparison in this chapter has essentially no free parameters on either side, which is precisely what makes a clean surrogate-versus-surrogate reading possible.
 
+\subsection{TPE Sensitivity to Its Gamma Hyperparameter}
+\label{tpe_sensitivity_protocol}
+
+TPE is not parameter-free in the same sense. As discussed in the surrogate models chapter, Optuna's \texttt{TPESampler} reduces, for our purposes, to a single hyperparameter worth tuning: $\gamma \in [0,1]$, the quantile of completed trials treated as "good" versus "bad." Everywhere else in this chapter TPE is run with Optuna's library default for $\gamma$, exactly as a practitioner reaching for the reference implementation would. To check whether that default is doing meaningful work -- and, by extension, whether BASS-BO's complete absence of such a knob is a genuine practical advantage rather than a cosmetic one -- we ran a separate ablation: $\gamma$ was swept over $\{0.10, 0.25, 0.50, 0.75\}$ (0.25 sits close to Optuna's own default behavior) on one continuous benchmark (Branin) and one purely categorical one (Cat-Ackley), under the same budget, repetition count, and seeding protocol as the rest of this chapter. The resulting four TPE curves were plotted alongside the single, unsweepable BASS-BO and GP-BO reference curves, so the contrast is visual as much as numerical: where TPE's curves fan out across configurations, BASS-BO and GP-BO have nothing to fan out. The script and full protocol are in \texttt{code\_files/2\_tpe\_sensitivity/}.
+
 \section{Results}
 
 What follows are the graphs representing some runs from the BASS-BO cycle, compared to GP-BO and Random Search. We ran these optimizers across the benchmark functions described above, spanning smooth continuous problems as well as categorical and mixed-variable ones, so as to get wider coverage into the actual performance of the optimizers across qualitatively different regimes.
@@ -153,6 +158,19 @@ To stress the categorical capability in isolation, we also use a purely categori
 \begin{figure}[h]
 	\centering
 	\fbox{\begin{minipage}[c][5cm][c]{14cm}\centering\textit{[Cat-Ackley convergence plot pending --- run \texttt{Rscript code\_files/run\_benchmark.R -{}-objective=cat\_ackley -{}-d=6}.]}\end{minipage}}
+\end{figure}
+
+\subsection{TPE Hyperparameter Sensitivity}
+
+As described in Section~\ref{tpe_sensitivity_protocol}, we swept TPE's $\gamma$ hyperparameter over $\{0.10, 0.25, 0.50, 0.75\}$ on Branin and Cat-Ackley, holding everything else (budget, repetitions, seeding, initial design) fixed to the same protocol used throughout this chapter. The figures below plot the four resulting TPE curves alongside the single BASS-BO and GP-BO reference curves.
+
+% TODO: insert TPE gamma-sensitivity convergence plots (Branin and Cat-Ackley)
+%   Rscript code_files/2_tpe_sensitivity/run_tpe_sensitivity.R
+% TODO: quote the printed "TPE final-best range across gamma" spread for each
+%   objective here, and contrast it with BASS-BO/GP-BO having no such spread.
+\begin{figure}[h]
+	\centering
+	\fbox{\begin{minipage}[c][5cm][c]{14cm}\centering\textit{[TPE gamma-sensitivity convergence plots pending --- run \texttt{Rscript code\_files/2\_tpe\_sensitivity/run\_tpe\_sensitivity.R}.]}\end{minipage}}
 \end{figure}
 
 \section{Result Interpretation and Limitations}


### PR DESCRIPTION
TPE now out-converges BASS-BO at large candidate counts, so the
"no tuning needed" argument for BASS-BO needs evidence rather than
assertion. Sweep Optuna's TPESampler gamma quantile across Branin and
Cat-Ackley and plot it against the single, unsweepable BASS-BO/GP-BO
curves to make the contrast measurable.

- R/tpe.R: run_tpe() accepts an optional sampler_opts list forwarded to
  TPESampler (default list() preserves current behavior); add
  run_tpe_sweep_experiment() to stack one labeled curve per (seed, config).
- code_files/2_tpe_sensitivity/: new driver script + README running the
  gamma sweep (0.10/0.25/0.50/0.75) against the reference curves.
- tests/testthat/test-tpe-sensitivity.R: contract + wiring checks, same
  skip-if-unavailable pattern as test-tpe.R.
- README.md / RUNNING.md: document the new script and section.
- Experiment.tex: methodology subsection + results placeholder for the
  ablation, cross-referenced via \label/\ref.