### PR TITLE
Make candidate generation schema-aware for categorical inputs

### DIFF
--- a/code_files/R/bo_loop.R
+++ b/code_files/R/bo_loop.R
@@ -70,17 +70,21 @@ run_bo <- function(objective, method, cfg, X_init, y_init) {
 #' (Expected Improvement), so the surrogate is the only thing that differs --
 #' which is exactly the comparison the thesis is about.
 #'
-#' For categorical/mixed objectives the `schema` is forwarded only to BASS-BO, so
-#' BASS fits on genuine factors. GP-BO gets no schema on purpose: a plain GP has
-#' no categorical kernel, so it sees the raw [0,1] coordinate -- a continuous
-#' relaxation of the categories. That gap is the whole point of the comparison.
+#' For categorical/mixed objectives the `schema` is forwarded to BASS-BO's
+#' acquisition, so BASS fits on genuine factors. GP-BO's acquisition gets no
+#' schema on purpose: a plain GP has no categorical kernel, so it sees the raw
+#' [0,1] coordinate -- a continuous relaxation of the categories. That gap is the
+#' whole point of the comparison. The shared candidate generator, however, *does*
+#' get the schema for both methods, so both score a pool with sensible categorical
+#' moves (see candidates.R); keeping the generator common is what preserves the
+#' surrogate as the only difference between BASS-BO and GP-BO.
 #'
 #' @param cfg    Config list (see `default_config()`).
 #' @param schema Optional input schema from the objective (NULL = all continuous).
 #' @return Named list of methods: BASS-BO, GP-BO, Random.
 make_methods <- function(cfg, schema = NULL) {
   shared_candidates <- function(X_eval, y_eval)
-    hybrid_candidates(X_eval, y_eval, cfg$n_cand)
+    hybrid_candidates(X_eval, y_eval, cfg$n_cand, schema)
 
   list(
     "BASS-BO" = list(

--- a/code_files/R/candidates.R
+++ b/code_files/R/candidates.R
@@ -13,6 +13,17 @@
 # There are no local_frac / local_sd knobs to set: the split is a fixed 50/50
 # and the width is derived, not tuned.
 #
+# Categorical coordinates need a different notion of "local". A Gaussian nudge of
+# the unit-cube coordinate is an *ordinal* move -- it can only reach the
+# incumbent's level and its index-neighbours -- which is meaningless for an
+# unordered factor (and actively wrong when the levels are permuted, as in
+# Cat-Ackley). So when an objective supplies a `schema`, the local half instead
+# makes Hamming-local moves on the categorical coordinates: it keeps most of them
+# at the incumbent's level and flips a small random subset to uniformly-random
+# *other* levels. Continuous coordinates still get the Gaussian cloud, so mixed
+# problems get a sensible joint local move. This generator is shared by BASS-BO
+# and GP-BO, so the surrogate remains the only thing that differs between them.
+#
 # Pure functions -- easy to unit-test.
 # =============================================================================
 
@@ -75,20 +86,58 @@ local_scale <- function(X_eval, best_idx) {
   min(max(dmin, 1e-2), 0.5)
 }
 
+#' Replace the categorical coordinates of a local cloud with Hamming-local moves.
+#'
+#' Each row keeps the incumbent's level on most categorical coordinates and flips
+#' a small random subset (1..min(3, #cat)) to uniformly-random *other* levels --
+#' the correct notion of "nearby" for an unordered factor. Chosen levels are
+#' written back as bin centres, `(level - 0.5) / L`, which decode exactly to that
+#' level (see decode_levels) and dedupe cleanly across iterations. Continuous
+#' coordinates in `X_local` are left untouched.
+#'
+#' @param X_local n x d local-cloud matrix (continuous coords already filled in).
+#' @param x_best  The incumbent point (length-d vector in [0,1]^d).
+#' @param schema  Input schema with `types` and `levels` (see objective_utils.R).
+#' @param cat_idx Integer indices of the categorical coordinates.
+#' @return        `X_local` with its categorical columns rewritten.
+local_categorical_moves <- function(X_local, x_best, schema, cat_idx) {
+  n_cat   <- length(cat_idx)
+  inc_lev <- vapply(cat_idx,
+                    function(j) as.integer(decode_levels(x_best[j], schema$levels[j])),
+                    integer(1))
+
+  for (r in seq_len(nrow(X_local))) {
+    k    <- sample.int(min(3L, n_cat), 1L)   # how many coords to flip (>= 1)
+    flip <- sample.int(n_cat, k)             # which categorical coords to flip
+    for (c in seq_len(n_cat)) {
+      j   <- cat_idx[c]
+      L   <- schema$levels[j]
+      lev <- inc_lev[c]
+      if (c %in% flip) lev <- sample(setdiff(seq_len(L), lev), 1L)
+      X_local[r, j] <- (lev - 0.5) / L       # bin centre -> decodes back to `lev`
+    }
+  }
+  X_local
+}
+
 #' Hybrid global + adaptive-local candidate set (parameter-free).
 #'
 #' @param X_eval m x d matrix of evaluated points.
 #' @param y_eval Length-m objective values (best = smallest).
 #' @param n_cand Total number of candidates to return.
+#' @param schema Optional input schema (see objective_utils.R). When it marks
+#'   categorical coordinates, the local half makes Hamming-local moves on them
+#'   instead of an (ill-defined) ordinal Gaussian nudge; NULL => all-continuous,
+#'   the original behaviour.
 #' @return       An n_cand x d matrix in [0,1]^d.
-hybrid_candidates <- function(X_eval, y_eval, n_cand) {
+hybrid_candidates <- function(X_eval, y_eval, n_cand, schema = NULL) {
   X_eval <- as.matrix(X_eval)
   d <- ncol(X_eval)
 
   n_local  <- floor(n_cand / 2)
   n_global <- n_cand - n_local
 
-  # Global half: even coverage of the whole cube.
+  # Global half: even coverage of the whole cube (uniform levels for categoricals).
   X_global <- space_filling_candidates(n_global, d)
 
   # Local half: a Gaussian cloud around the incumbent, width set by the data,
@@ -101,6 +150,15 @@ hybrid_candidates <- function(X_eval, y_eval, n_cand) {
     ncol = d
   )
   X_local <- pmin(pmax(X_local, 0), 1)
+
+  # On categorical coordinates the Gaussian nudge is the wrong move; replace it
+  # with Hamming-local flips around the incumbent's levels.
+  if (!is.null(schema) && n_local > 0) {
+    cat_idx <- which(schema$types == "cat")
+    if (length(cat_idx)) {
+      X_local <- local_categorical_moves(X_local, x_best, schema, cat_idx)
+    }
+  }
 
   rbind(X_global, X_local)
 }

--- a/code_files/tests/testthat/test-candidates.R
+++ b/code_files/tests/testthat/test-candidates.R
@@ -34,3 +34,46 @@ test_that("hybrid_candidates returns exactly n_cand points in the unit cube", {
   expect_equal(ncol(X), 2)
   expect_true(all(X >= 0 & X <= 1))   # local cloud must be clipped into [0,1]
 })
+
+test_that("schema-aware local half makes Hamming-local categorical moves", {
+  set.seed(1)
+  d <- 5L; L <- 7L
+  schema <- list(types = rep("cat", d), levels = rep(L, d))
+  X_eval <- matrix(runif(20 * d), ncol = d)
+  y_eval <- runif(20)
+  n_cand <- 400
+  X <- hybrid_candidates(X_eval, y_eval, n_cand = n_cand, schema = schema)
+  expect_equal(dim(X), c(n_cand, d))
+
+  inc <- decode_levels(X_eval[which.min(y_eval), ], L)
+  n_local <- floor(n_cand / 2)
+  local_rows <- X[(n_cand - n_local + 1):n_cand, , drop = FALSE]
+  levs <- t(apply(local_rows, 1, decode_levels, L = L))
+
+  # Categorical coords sit on bin centres, so they decode back exactly.
+  expect_true(all(abs(local_rows * L - (floor(local_rows * L) + 0.5)) < 1e-9))
+
+  # Every local move differs from the incumbent in 1..3 coordinates (Hamming-local).
+  ham <- rowSums(sweep(levs, 2, inc, "!=") != 0)
+  expect_true(all(ham >= 1 & ham <= 3))
+
+  # Flips can reach non-adjacent levels (not just index neighbours): some coord
+  # should land more than one level away from the incumbent at least once.
+  expect_true(any(abs(sweep(levs, 2, inc, "-")) > 1))
+})
+
+test_that("hybrid_candidates leaves continuous coords Gaussian under a mixed schema", {
+  set.seed(2)
+  # Two categorical + two continuous, like Func-2C.
+  schema <- list(types = c("cat", "cat", "cont", "cont"),
+                 levels = c(3L, 5L, NA, NA))
+  X_eval <- matrix(runif(12 * 4), ncol = 4)
+  y_eval <- runif(12)
+  X <- hybrid_candidates(X_eval, y_eval, n_cand = 200, schema = schema)
+  expect_equal(dim(X), c(200, 4))
+  expect_true(all(X >= 0 & X <= 1))
+
+  # Continuous coords are NOT snapped to bin centres (they stay genuinely spread).
+  local_rows <- X[101:200, 3:4, drop = FALSE]
+  expect_gt(length(unique(round(local_rows[, 1], 6))), 50)
+})


### PR DESCRIPTION
## What

The local half of `hybrid_candidates()` applied a Gaussian nudge to every coordinate. That is an **ordinal** move: on a categorical coordinate it can only reach the incumbent's level and its index-neighbours (and degrades to ~uniform when the design is sparse). That is meaningless for an unordered factor and actively wrong when the levels are permuted (Cat-Ackley), so model-based **exploitation over categoricals was effectively Random Search**.

This threads the objective's `schema` into the shared candidate generator (used by both BASS-BO and GP-BO, so the *surrogate* stays the only difference between them). For categorical coordinates the local half now makes **Hamming-local moves**: keep the incumbent's level on most coordinates, flip a small random subset (1–3) to uniformly-random *other* levels, snapped to bin centres so they decode exactly and dedupe cleanly. Continuous coordinates still get the Gaussian cloud, so mixed problems get a sensible joint local move. Continuous-only behaviour (`schema = NULL`) is unchanged.

## Why it matters / what it does *not* establish

The old behaviour was a genuine confound and this is a methodological fix worth keeping on its own merits. But to be clear about scope: it does **not** by itself make BASS-BO win on categorical problems.

Before → after final best-so-far (lower is better), full protocol (budget 80, reps 25):

| Benchmark | Method | Before | After |
|---|---|---|---|
| Cat-Ackley | **GP-BO** | 18.13 | **14.82 (now 1st)** |
| Cat-Ackley | TPE | 16.62 | 16.62 |
| Cat-Ackley | **BASS-BO** | 18.27 (last) | 17.67 (3rd) |
| Func-2C | **BASS-BO** | −0.024 (last) | +0.004 (last) |
| Func-3C | **BASS-BO** | −0.018 (last) | +0.062 (last) |

The fix helps model-based exploitation materially on the purely-categorical Cat-Ackley (both surrogates jump while Random stays flat), but the **GP continuous relaxation is the biggest beneficiary** and is now the best method there; BASS-BO improves modestly and remains the weakest surrogate on the mixed benchmarks. Why BASS-BO still trails is the subject of a follow-up investigation.

The continuous benchmarks (Branin, Rastrigin, Synthetic) and all TPE numbers are byte-identical before/after, confirming the change is cleanly isolated to categorical handling with no regression.

## Tests

`test-candidates.R` adds coverage for the Hamming-local moves (distance 1–3, bin-centre decoding, non-adjacent reachability) and that continuous coords stay Gaussian under a mixed schema. Full suite green.

