### PR TITLE
Fix categorical BO bottlenecks: keep-combo local moves, combination-level dedup, discriminating benchmarks, paired stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Rscript code_files/run_benchmark.R --objective=branin --acquisition=thompson
 # (needs reticulate + optuna; see RUNNING.md §1)
 Rscript code_files/run_benchmark.R --objective=func2C --with_tpe=true
 Rscript code_files/run_benchmark.R --objective=cat_ackley --d=6 --with_tpe=true
+
+# Cat-Ackley at an easy size (5^3 = 125 combinations, solvable in-budget)
+Rscript code_files/run_benchmark.R --objective=cat_ackley --d=3 --cat_L=5
 ```
 
 A separate ablation, `code_files/2_tpe_sensitivity/run_tpe_sensitivity.R`,

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -141,6 +141,7 @@ Every key in `default_config()` (`code_files/R/config.R`) is settable as
 |---|---|---|
 | `--objective` | `branin` | `branin`, `rastrigin`, `synthetic`, `func2C`, `func3C`, `cat_ackley` |
 | `--d` | `2` | input dimension (Branin must be 2; `func2C`/`func3C` are fixed) |
+| `--cat_L` | `11` | levels per categorical input, `cat_ackley` only (odd); sets instance size `L^d` |
 | `--budget` | `80` | BO iterations after the initial design |
 | `--n_cand` | `1000` | candidate points scored per iteration |
 | `--reps` | `10` | independent repetitions (seeds) |
@@ -156,6 +157,12 @@ natively, so it is the strongest comparison there:
 ```bash
 Rscript code_files/run_benchmark.R --objective=func2C --with_tpe=true
 Rscript code_files/run_benchmark.R --objective=cat_ackley --d=6 --with_tpe=true
+
+# Cat-Ackley instance size is a protocol choice: L^d combinations. The easy
+# instance is solvable within the default budget (capability demonstration);
+# the hard one shows the budget-limited regime.
+Rscript code_files/run_benchmark.R --objective=cat_ackley --d=3 --cat_L=5   # easy: 125
+Rscript code_files/run_benchmark.R --objective=cat_ackley --d=6 --cat_L=11  # hard: 1.77M
 ```
 
 ---
@@ -233,7 +240,7 @@ nothing overwrites anything else:
 
 | Runner | Output location |
 |---|---|
-| `run_benchmark.R` | `results/<objective>/` (e.g. `results/branin/`, `results/cat_ackley/`) |
+| `run_benchmark.R` | `results/<objective>/` (e.g. `results/branin/`; Cat-Ackley includes its size: `results/cat_ackley_d6_L11/`) |
 | `2_tpe_sensitivity/run_tpe_sensitivity.R` | `results/tpe_sensitivity/<objective>/` |
 | `4_regression_test_case/run_elastic_net.R` | `results/elastic_net/` |
 

--- a/code_files/2_tpe_sensitivity/run_tpe_sensitivity.R
+++ b/code_files/2_tpe_sensitivity/run_tpe_sensitivity.R
@@ -79,7 +79,7 @@ make_configs <- function() {
 
 # --- One objective: reference curves (BASS-BO/GP-BO/Random) + the gamma sweep -
 run_one_objective <- function(cfg) {
-  objective <- load_objective(cfg$objective, cfg$d)
+  objective <- load_objective(cfg$objective, cfg$d, cfg$cat_L)
   cat(sprintf("\n== %s (d=%d) | budget=%d | reps=%d ==\n",
               cfg$objective, objective$d, cfg$budget, cfg$reps))
 

--- a/code_files/3_categorical_diagnostics/README.md
+++ b/code_files/3_categorical_diagnostics/README.md
@@ -1,0 +1,54 @@
+# Categorical diagnostics
+
+Why doesn't BASS-BO separate from Random Search on the categorical/mixed
+benchmarks? This folder contains one script that splits that question into
+three independently answerable parts, ordered from the outside in:
+
+1. **Oracle ceiling** (runs without BASS). The acquisition is replaced by the
+   true objective, so the loop always picks the best point in the candidate
+   pool. This upper-bounds what *any* surrogate could achieve with the current
+   `hybrid_candidates()` generator, and compares it against a patched
+   generator whose local rows may **keep** the incumbent's categorical
+   combination. The current generator always flips at least one categorical
+   coordinate (`local_categorical_moves()` draws `k` from `1..min(3, n_cat)`),
+   so no candidate ever refines the continuous coordinates while holding the
+   best-known combination fixed — on Func-2C/3C that is exactly the local
+   exploitation a model-based method needs to beat Random.
+
+2. **BASS fit quality at BO sample sizes.** Held-out Spearman correlation of
+   the BASS posterior mean vs the truth, fit on n0 / n0+20 / n0+budget random
+   points. If this is ≈ 0 (plausible for Cat-Ackley with d=6, L=11: 1.77M
+   combinations, 66 free level effects, ~90 observations), the benchmark
+   cannot show a surrogate advantage at thesis budgets *no matter what the
+   acquisition does*, and the honest fix is to re-scale the benchmark (fewer
+   levels/dimensions or more budget), not to tune the method.
+
+3. **Instrumented BASS-BO vs Random**, paired per seed (shared initial
+   design): per-pick provenance (global LHS half vs local Hamming half),
+   revisited-combination counts (wasted evaluations on a deterministic
+   objective), paired win rates, and a Wilcoxon signed-rank test. Includes an
+   "easy mode" Cat-Ackley (d=3, L=5: 125 combinations) as a pass/fail
+   regression: if BASS-BO does not clearly beat Random there, the problem is
+   in the method wiring, not benchmark hardness.
+
+## Running
+
+```bash
+# Full diagnostic (needs BASS for parts 2-3; part 1 runs regardless)
+Rscript code_files/3_categorical_diagnostics/run_diagnostics.R
+
+# Faster pass
+Rscript code_files/3_categorical_diagnostics/run_diagnostics.R --reps=5 --budget=40
+```
+
+Prints a summary and writes `oracle_ceiling.csv`, `bass_fit_quality.csv`,
+`instrumented_runs.csv` under `results/diagnostics/`.
+
+## How to read the outcome
+
+| Observation | Conclusion |
+|---|---|
+| Oracle+current ≈ Random on func2C/3C, oracle+keep-combo clearly better | Candidate generator is the bottleneck: allow zero-flip local moves on mixed problems |
+| Part-2 Spearman ≈ 0 at n ≈ 90 on cat_ackley (d=6, L=11) | Benchmark is uninformative at this budget; re-scale it rather than tuning methods |
+| Easy-mode cat_ackley: BASS-BO does not beat Random | Something is broken in the surrogate/acquisition wiring itself |
+| High revisit counts in part 3 | EI keeps re-picking already-evaluated combinations; deduplicate at the decoded-combination level |

--- a/code_files/3_categorical_diagnostics/README.md
+++ b/code_files/3_categorical_diagnostics/README.md
@@ -6,14 +6,15 @@ three independently answerable parts, ordered from the outside in:
 
 1. **Oracle ceiling** (runs without BASS). The acquisition is replaced by the
    true objective, so the loop always picks the best point in the candidate
-   pool. This upper-bounds what *any* surrogate could achieve with the current
-   `hybrid_candidates()` generator, and compares it against a patched
+   pool. This upper-bounds what *any* surrogate could achieve with the
+   `hybrid_candidates()` generator, and compares it against a reference
    generator whose local rows may **keep** the incumbent's categorical
-   combination. The current generator always flips at least one categorical
-   coordinate (`local_categorical_moves()` draws `k` from `1..min(3, n_cat)`),
-   so no candidate ever refines the continuous coordinates while holding the
-   best-known combination fixed — on Func-2C/3C that is exactly the local
-   exploitation a model-based method needs to beat Random.
+   combination. Historically the library generator always flipped at least
+   one categorical coordinate, so no candidate ever refined the continuous
+   coordinates while holding the best-known combination fixed — on Func-2C/3C
+   exactly the local exploitation a model-based method needs to beat Random.
+   That is fixed (the library keeps combinations on mixed schemas now), so
+   this part remains as a regression check: the two arms should perform alike.
 
 2. **BASS fit quality at BO sample sizes.** Held-out Spearman correlation of
    the BASS posterior mean vs the truth, fit on n0 / n0+20 / n0+budget random
@@ -48,7 +49,31 @@ Prints a summary and writes `oracle_ceiling.csv`, `bass_fit_quality.csv`,
 
 | Observation | Conclusion |
 |---|---|
-| Oracle+current ≈ Random on func2C/3C, oracle+keep-combo clearly better | Candidate generator is the bottleneck: allow zero-flip local moves on mixed problems |
+| Oracle+current clearly worse than oracle+keep-combo on func2C/3C | Candidate-generator regression: local moves must be able to keep the incumbent's combination on mixed schemas |
 | Part-2 Spearman ≈ 0 at n ≈ 90 on cat_ackley (d=6, L=11) | Benchmark is uninformative at this budget; re-scale it rather than tuning methods |
 | Easy-mode cat_ackley: BASS-BO does not beat Random | Something is broken in the surrogate/acquisition wiring itself |
-| High revisit counts in part 3 | EI keeps re-picking already-evaluated combinations; deduplicate at the decoded-combination level |
+| High revisit counts in part 3 | Combination-level dedup regression: the loop is re-evaluating decoded combinations |
+
+## Findings from the first full run (2026-07, pre-fix library)
+
+These diagnostics were run once against the pre-fix library and drove the
+fixes now in the shared code:
+
+- **Part 1**: the keep-combo generator beat the always-flip one in **15/15
+  paired seeds** on func2C and func3C (reaching the func2C optimum −0.206
+  within ~10 evaluations, vs a −0.148 plateau); on purely categorical
+  Cat-Ackley both arms reached the optimum, clearing the pool. → fixed in
+  `local_categorical_moves()` (zero-flip moves allowed on mixed schemas).
+- **Part 2**: held-out Spearman at n ≈ 70: func2C ≈ 0.66, func3C ≈ 0.61,
+  cat_ackley d=6/L=11 ≈ 0.47 with near-intercept fits — the hard instance
+  cannot show a surrogate advantage at thesis budgets. → Cat-Ackley size is
+  now a protocol knob (`--cat_L`), benchmarked at easy/medium/hard.
+- **Part 3**: easy-mode Cat-Ackley: BASS-BO found the exact optimum **10/10
+  seeds** (Random 5/10) — the method wiring works — but **25–29 of 40 picks
+  revisited already-evaluated combinations**. → fixed by combination-level
+  dedup (`canonicalize()`). func2C: Random won 6/10 (2 ties) — consistent
+  with the Part-1 generator finding. cat_ackley d=6: BASS-BO won 9/10.
+
+**Post-fix expectations**: Part 1's two arms within noise of each other;
+Part 3 revisit counts ≈ 0 everywhere; func2C paired wins flipped in
+BASS-BO's favour; easy-mode still 10/10.

--- a/code_files/3_categorical_diagnostics/run_diagnostics.R
+++ b/code_files/3_categorical_diagnostics/run_diagnostics.R
@@ -1,0 +1,300 @@
+#!/usr/bin/env Rscript
+
+# =============================================================================
+# run_diagnostics.R  --  Why doesn't BASS-BO beat Random on categorical tasks?
+# =============================================================================
+# Three diagnostics that separate the possible causes, from the outside in:
+#
+#   1) ORACLE CEILING (no BASS needed). Replace the acquisition with the true
+#      objective (score = -f). The loop then always picks the best point in the
+#      candidate pool, so the result is an upper bound on what ANY surrogate
+#      could achieve with the current hybrid_candidates() generator. A second
+#      arm uses a patched generator whose local rows may KEEP the incumbent's
+#      categorical combination (the current one always flips >= 1 categorical
+#      coordinate, so the continuous coordinates can never be refined at the
+#      best known combination). If oracle+current barely beats Random, the
+#      candidate pool -- not the surrogate -- is the bottleneck.
+#
+#   2) SURROGATE FIT QUALITY (needs BASS). Fit BASS on n random points of the
+#      objective and measure Spearman rank correlation between the posterior
+#      mean and the truth on held-out points, at the sample sizes the BO loop
+#      actually sees (n0, n0+20, n0+80). If this is ~0, BASS cannot learn the
+#      benchmark at thesis budgets and no acquisition will save it: the
+#      benchmark is uninformative at this scale, not "BASS-BO is bad".
+#
+#   3) INSTRUMENTED BASS-BO RUNS (needs BASS). Run BASS-BO vs Random with
+#      per-pick logging: was the pick a global (LHS) or local (Hamming)
+#      candidate, and did its decoded categorical combination duplicate one
+#      already evaluated (a wasted evaluation on a deterministic objective)?
+#      Also an "easy mode" Cat-Ackley (d=3, L=5: 125 combinations) where a
+#      correctly working BASS-BO MUST clearly beat Random -- a pass/fail
+#      regression for the whole method.
+#
+# Usage:
+#   Rscript code_files/3_categorical_diagnostics/run_diagnostics.R
+#   Rscript code_files/3_categorical_diagnostics/run_diagnostics.R --reps=5 --budget=40
+#
+# Results are printed and written under results/diagnostics/.
+# =============================================================================
+
+suppressPackageStartupMessages({ library(lhs) })
+has_bass <- requireNamespace("BASS", quietly = TRUE)
+
+this_file  <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+script_dir <- if (length(this_file)) dirname(normalizePath(this_file)) else getwd()
+lib_dir    <- normalizePath(file.path(script_dir, "..", "R"))
+source(file.path(lib_dir, "bootstrap.R"))
+source_library(lib_dir)
+
+cfg <- default_config()
+cfg$budget <- 60L
+cfg$reps   <- 10L
+cfg <- parse_cli_args(commandArgs(trailingOnly = TRUE), cfg)
+out_dir <- file.path("results", "diagnostics")
+dir.create(out_dir, showWarnings = FALSE, recursive = TRUE)
+
+seeds <- cfg$seed_start + 0:(cfg$reps - 1)
+
+# --- Shared helpers -----------------------------------------------------------
+
+# Key a point by its decoded categorical levels (continuous coords rounded, so
+# on purely categorical problems the key IS the combination).
+combo_key <- function(x, schema) {
+  paste(vapply(seq_along(x), function(j) {
+    if (schema$types[j] == "cat") as.character(decode_levels(x[j], schema$levels[j]))
+    else sprintf("%.4f", x[j])
+  }, character(1)), collapse = "|")
+}
+
+shared_init <- function(objective, seed) {
+  set.seed(seed)
+  n0 <- max(2 * objective$d + 1, 8)
+  X_init <- lhs::maximinLHS(n0, objective$d)
+  list(X = X_init, y = objective$fn(X_init), n0 = n0)
+}
+
+# --- Patched local move: may keep the incumbent's combination -----------------
+# Flip each categorical coordinate independently with prob 1/n_cat (so ~37% of
+# local rows keep the full incumbent combination and refine only the continuous
+# coordinates). The current generator always flips 1..3 coordinates.
+local_categorical_moves_keep <- function(X_local, x_best, schema, cat_idx) {
+  n_cat   <- length(cat_idx)
+  inc_lev <- vapply(cat_idx,
+                    function(j) as.integer(decode_levels(x_best[j], schema$levels[j])),
+                    integer(1))
+  for (r in seq_len(nrow(X_local))) {
+    flip <- which(runif(n_cat) < 1 / n_cat)
+    for (c in seq_len(n_cat)) {
+      j   <- cat_idx[c]
+      L   <- schema$levels[j]
+      lev <- inc_lev[c]
+      if (c %in% flip) lev <- sample(setdiff(seq_len(L), lev), 1L)
+      X_local[r, j] <- (lev - 0.5) / L
+    }
+  }
+  X_local
+}
+
+hybrid_candidates_keep <- function(X_eval, y_eval, n_cand, schema = NULL) {
+  X_eval <- as.matrix(X_eval)
+  d <- ncol(X_eval)
+  n_local  <- floor(n_cand / 2)
+  n_global <- n_cand - n_local
+  X_global <- space_filling_candidates(n_global, d)
+  best_idx <- which.min(y_eval)
+  x_best   <- X_eval[best_idx, ]
+  s        <- local_scale(X_eval, best_idx)
+  X_local  <- matrix(rnorm(n_local * d, mean = rep(x_best, each = n_local), sd = s),
+                     ncol = d)
+  X_local  <- pmin(pmax(X_local, 0), 1)
+  if (!is.null(schema) && n_local > 0) {
+    cat_idx <- which(schema$types == "cat")
+    if (length(cat_idx)) {
+      X_local <- local_categorical_moves_keep(X_local, x_best, schema, cat_idx)
+    }
+  }
+  rbind(X_global, X_local)
+}
+
+# =============================================================================
+# 1) ORACLE CEILING
+# =============================================================================
+cat("==========================================================\n")
+cat("1) Oracle ceiling: candidate pool quality, surrogate-free\n")
+cat("==========================================================\n")
+
+oracle_rows <- list()
+for (obj_spec in list(list(name = "func2C", d = 4L),
+                      list(name = "func3C", d = 5L),
+                      list(name = "cat_ackley", d = 6L))) {
+  finals <- t(vapply(seeds, function(seed) {
+    objective <- load_objective(obj_spec$name, obj_spec$d)
+    schema    <- objective$schema
+    o_now <- list(name = "oracle+current",
+      candidates = function(X, y) hybrid_candidates(X, y, cfg$n_cand, schema),
+      acquire    = function(X, y, Xc) -objective$fn(Xc))
+    o_fix <- list(name = "oracle+keep-combo",
+      candidates = function(X, y) hybrid_candidates_keep(X, y, cfg$n_cand, schema),
+      acquire    = function(X, y, Xc) -objective$fn(Xc))
+    rnd   <- list(name = "Random", candidates = NULL, acquire = NULL)
+
+    init <- shared_init(objective, seed)
+    c(current = tail(run_bo(objective, o_now, cfg, init$X, init$y)$best, 1),
+      keep    = tail(run_bo(objective, o_fix, cfg, init$X, init$y)$best, 1),
+      random  = tail(run_bo(objective, rnd,   cfg, init$X, init$y)$best, 1))
+  }, numeric(3)))
+
+  cat(sprintf("\n%s (budget=%d, reps=%d) -- mean final best (lower is better):\n",
+              obj_spec$name, cfg$budget, cfg$reps))
+  cat(sprintf("  oracle + current generator   : %9.4f\n", mean(finals[, "current"])))
+  cat(sprintf("  oracle + keep-combo generator: %9.4f\n", mean(finals[, "keep"])))
+  cat(sprintf("  Random                       : %9.4f\n", mean(finals[, "random"])))
+  cat(sprintf("  paired wins: keep<current %d/%d | current<random %d/%d\n",
+              sum(finals[, "keep"] < finals[, "current"]), nrow(finals),
+              sum(finals[, "current"] < finals[, "random"]), nrow(finals)))
+  oracle_rows[[obj_spec$name]] <- data.frame(objective = obj_spec$name,
+                                             seed = seeds, finals)
+}
+write.csv(do.call(rbind, oracle_rows),
+          file.path(out_dir, "oracle_ceiling.csv"), row.names = FALSE)
+
+if (!has_bass) {
+  cat("\nBASS is not installed; skipping diagnostics 2 and 3.\n")
+  quit(save = "no")
+}
+
+# =============================================================================
+# 2) SURROGATE FIT QUALITY AT BO SAMPLE SIZES
+# =============================================================================
+cat("\n==========================================================\n")
+cat("2) BASS fit quality at the sample sizes the BO loop sees\n")
+cat("==========================================================\n")
+
+fit_quality <- function(objective, n_fit, seed) {
+  schema <- objective$schema
+  if (!is.null(schema)) .ensure_bass_cat_predict_fix()
+  set.seed(seed)
+  d <- objective$d
+  X <- matrix(runif(n_fit * d), ncol = d)
+  y <- objective$fn(X)
+  y_std <- (y - mean(y)) / max(sd(y), 1e-12)
+  fit <- BASS::bass(xx = to_model_frame(X, schema), y = y_std,
+                    nmcmc = BASS_NMCMC, nburn = BASS_NBURN, thin = BASS_THIN,
+                    verbose = FALSE)
+  X_test <- matrix(runif(500 * d), ncol = d)
+  y_test <- objective$fn(X_test)
+  draws  <- .samples_by_cand(predict(fit, to_model_frame(X_test, schema),
+                                     mcmc.use = seq_len(BASS_KEEP)), 500L)
+  pm <- colMeans(draws)
+  c(spearman = cor(pm, y_test, method = "spearman"),
+    nbasis   = mean(fit$nbasis))
+}
+
+fq_rows <- list()
+for (obj_spec in list(list(name = "func2C", d = 4L),
+                      list(name = "func3C", d = 5L),
+                      list(name = "cat_ackley", d = 6L))) {
+  objective <- load_objective(obj_spec$name, obj_spec$d)
+  n0 <- max(2 * objective$d + 1, 8)
+  for (n_fit in c(n0, n0 + 20L, n0 + cfg$budget)) {
+    r <- t(vapply(seeds[seq_len(min(5, length(seeds)))],
+                  function(s) fit_quality(objective, n_fit, s), numeric(2)))
+    cat(sprintf("  %-10s n=%3d : held-out Spearman(pred, truth) = %5.2f (+/- %.2f), mean #basis = %4.1f\n",
+                obj_spec$name, n_fit, mean(r[, "spearman"]), sd(r[, "spearman"]),
+                mean(r[, "nbasis"])))
+    fq_rows[[paste(obj_spec$name, n_fit)]] <-
+      data.frame(objective = obj_spec$name, n_fit = n_fit,
+                 spearman = r[, "spearman"], nbasis = r[, "nbasis"])
+  }
+}
+write.csv(do.call(rbind, fq_rows),
+          file.path(out_dir, "bass_fit_quality.csv"), row.names = FALSE)
+
+# =============================================================================
+# 3) INSTRUMENTED BASS-BO vs RANDOM (paired per seed)
+# =============================================================================
+cat("\n==========================================================\n")
+cat("3) Instrumented BASS-BO runs (pick provenance + revisits)\n")
+cat("==========================================================\n")
+
+# Same loop as run_bo(), plus per-pick logging. Kept local to the diagnostic so
+# the library stays untouched.
+run_bo_logged <- function(objective, method, cfg, X_init, y_init) {
+  f      <- objective$fn
+  schema <- objective$schema
+  X_eval <- as.matrix(X_init)
+  y_eval <- as.numeric(y_init)
+  n_global <- cfg$n_cand - floor(cfg$n_cand / 2)
+
+  seen <- vapply(seq_len(nrow(X_eval)),
+                 function(i) combo_key(X_eval[i, ], schema), character(1))
+  best_so_far    <- numeric(cfg$budget + 1)
+  best_so_far[1] <- min(y_eval)
+  origin  <- character(cfg$budget)
+  revisit <- logical(cfg$budget)
+
+  for (t in 1:cfg$budget) {
+    X_cand <- method$candidates(X_eval, y_eval)
+    score  <- method$acquire(X_eval, y_eval, X_cand)
+    score[min_sqdist(X_cand, X_eval) <= cfg$dup_tol^2] <- -Inf
+    pick   <- which.max(score)
+    x_next <- X_cand[pick, , drop = FALSE]
+
+    origin[t]  <- if (pick <= n_global) "global" else "local"
+    k          <- combo_key(x_next[1, ], schema)
+    revisit[t] <- k %in% seen
+    seen       <- c(seen, k)
+
+    y_next <- f(x_next)
+    X_eval <- rbind(X_eval, x_next)
+    y_eval <- c(y_eval, y_next)
+    best_so_far[t + 1] <- min(y_eval)
+  }
+  list(best = best_so_far, origin = origin, revisit = revisit)
+}
+
+instrument_case <- function(obj_name, make_objective, budget) {
+  cfg_case <- cfg; cfg_case$budget <- budget
+  rows <- lapply(seeds, function(seed) {
+    objective <- make_objective()
+    methods   <- make_methods(cfg_case, objective$schema)
+    init      <- shared_init(objective, seed)
+    rb <- run_bo_logged(objective, methods[["BASS-BO"]], cfg_case, init$X, init$y)
+    rr <- run_bo(objective, methods[["Random"]], cfg_case, init$X, init$y)
+    data.frame(seed = seed,
+               bass_final = tail(rb$best, 1), random_final = tail(rr$best, 1),
+               n_local = sum(rb$origin == "local"),
+               n_revisit = sum(rb$revisit))
+  })
+  df <- do.call(rbind, rows)
+  cat(sprintf("\n%s (budget=%d, reps=%d):\n", obj_name, budget, cfg$reps))
+  cat(sprintf("  mean final best: BASS-BO %9.4f | Random %9.4f\n",
+              mean(df$bass_final), mean(df$random_final)))
+  cat(sprintf("  paired wins BASS<Random: %d/%d (shared initial design => paired)\n",
+              sum(df$bass_final < df$random_final), nrow(df)))
+  if (requireNamespace("stats", quietly = TRUE) && nrow(df) >= 6) {
+    p <- tryCatch(stats::wilcox.test(df$bass_final, df$random_final,
+                                     paired = TRUE)$p.value, error = function(e) NA)
+    cat(sprintf("  Wilcoxon signed-rank (paired) p = %.3f\n", p))
+  }
+  cat(sprintf("  BASS-BO picks: %.0f%% local-half | revisited combos: %.1f of %d picks\n",
+              100 * mean(df$n_local / budget), mean(df$n_revisit), budget))
+  df$objective <- obj_name
+  df
+}
+
+easy_cat_ackley <- function() {
+  ca <- make_cat_ackley(3L, L = 5L)   # 125 combinations: budget covers a third
+  list(name = "cat_ackley_easy", d = ca$d, fn = ca$fn, schema = ca$schema)
+}
+
+inst <- rbind(
+  # Easy mode: 125 combinations, a working BASS-BO MUST clearly beat Random.
+  instrument_case("cat_ackley_easy (d=3, L=5)", easy_cat_ackley, min(cfg$budget, 40L)),
+  instrument_case("func2C", function() load_objective("func2C", 4L), cfg$budget),
+  instrument_case("cat_ackley (d=6, L=11)",
+                  function() load_objective("cat_ackley", 6L), cfg$budget)
+)
+write.csv(inst, file.path(out_dir, "instrumented_runs.csv"), row.names = FALSE)
+
+cat(sprintf("\nAll diagnostic artifacts saved under: %s\n", normalizePath(out_dir)))

--- a/code_files/3_categorical_diagnostics/run_diagnostics.R
+++ b/code_files/3_categorical_diagnostics/run_diagnostics.R
@@ -9,11 +9,12 @@
 #      objective (score = -f). The loop then always picks the best point in the
 #      candidate pool, so the result is an upper bound on what ANY surrogate
 #      could achieve with the current hybrid_candidates() generator. A second
-#      arm uses a patched generator whose local rows may KEEP the incumbent's
-#      categorical combination (the current one always flips >= 1 categorical
-#      coordinate, so the continuous coordinates can never be refined at the
-#      best known combination). If oracle+current barely beats Random, the
-#      candidate pool -- not the surrogate -- is the bottleneck.
+#      arm uses a reference generator whose local rows may KEEP the incumbent's
+#      categorical combination. Historically the library generator always
+#      flipped >= 1 categorical coordinate, and this A/B exposed it (reference
+#      won 15/15 paired seeds on func2C/func3C); the library now keeps combos
+#      on mixed schemas too, so the two arms should perform alike -- this part
+#      is kept as a regression check on the candidate pool's ceiling.
 #
 #   2) SURROGATE FIT QUALITY (needs BASS). Fit BASS on n random points of the
 #      objective and measure Spearman rank correlation between the posterior
@@ -73,10 +74,11 @@ shared_init <- function(objective, seed) {
   list(X = X_init, y = objective$fn(X_init), n0 = n0)
 }
 
-# --- Patched local move: may keep the incumbent's combination -----------------
+# --- Reference local move: may keep the incumbent's combination ---------------
 # Flip each categorical coordinate independently with prob 1/n_cat (so ~37% of
 # local rows keep the full incumbent combination and refine only the continuous
-# coordinates). The current generator always flips 1..3 coordinates.
+# coordinates). The library generator now behaves the same way on mixed
+# schemas; this independent copy pins the expected behaviour for the A/B.
 local_categorical_moves_keep <- function(X_local, x_best, schema, cat_idx) {
   n_cat   <- length(cat_idx)
   inc_lev <- vapply(cat_idx,
@@ -236,8 +238,11 @@ run_bo_logged <- function(objective, method, cfg, X_init, y_init) {
   for (t in 1:cfg$budget) {
     X_cand <- method$candidates(X_eval, y_eval)
     score  <- method$acquire(X_eval, y_eval, X_cand)
-    score[min_sqdist(X_cand, X_eval) <= cfg$dup_tol^2] <- -Inf
-    pick   <- which.max(score)
+    # Mirror run_bo(): combination-level dedup + random tie-breaking.
+    score[min_sqdist(canonicalize(X_cand, schema),
+                     canonicalize(X_eval, schema)) <= cfg$dup_tol^2] <- -Inf
+    top    <- which(score == max(score))
+    pick   <- if (length(top) > 1L) sample(top, 1L) else top
     x_next <- X_cand[pick, , drop = FALSE]
 
     origin[t]  <- if (pick <= n_global) "global" else "local"

--- a/code_files/R/bo_loop.R
+++ b/code_files/R/bo_loop.R
@@ -31,6 +31,7 @@
 #'                    * `y`    : the objective value at each evaluated point.
 run_bo <- function(objective, method, cfg, X_init, y_init) {
   f      <- objective$fn
+  schema <- objective$schema   # NULL for purely continuous objectives
   X_eval <- as.matrix(X_init)
   y_eval <- as.numeric(y_init)
   d      <- ncol(X_eval)
@@ -39,18 +40,30 @@ run_bo <- function(objective, method, cfg, X_init, y_init) {
   best_so_far[1] <- min(y_eval)
 
   for (t in 1:cfg$budget) {
+    # Duplicates are judged on the canonical representation (categorical
+    # coordinates snapped to bin centres, see canonicalize): two encodings that
+    # decode to the same level combination are the same objective input, so
+    # re-evaluating one is a wasted iteration on a deterministic objective.
+    X_seen <- canonicalize(X_eval, schema)
+
     if (is.null(method$acquire)) {
       # ---- Random Search: a fresh, non-duplicate point ----
-      repeat {
+      # Attempts are capped: on a small categorical space that is nearly
+      # exhausted, an un-evaluated combination may not turn up, and accepting
+      # a duplicate then is better than spinning forever.
+      for (attempt in 1:100) {
         x_next <- matrix(runif(d), nrow = 1)
-        if (!is_duplicate(x_next, X_eval, cfg$dup_tol)) break
+        if (!is_duplicate(canonicalize(x_next, schema), X_seen, cfg$dup_tol)) break
       }
     } else {
       # ---- Model-based step: propose, score, take the best new candidate ----
       X_cand <- method$candidates(X_eval, y_eval)
       score  <- method$acquire(X_eval, y_eval, X_cand)
-      # Rule out candidates that duplicate an already-evaluated point.
-      score[min_sqdist(X_cand, X_eval) <= cfg$dup_tol^2] <- -Inf
+      # Rule out candidates that duplicate an already-evaluated point. (If the
+      # whole pool is masked -- conceivable only when a tiny categorical space
+      # is all but exhausted -- which.max still returns a point; a duplicate
+      # then costs one iteration, it does not break the loop.)
+      score[min_sqdist(canonicalize(X_cand, schema), X_seen) <= cfg$dup_tol^2] <- -Inf
       x_next <- X_cand[which.max(score), , drop = FALSE]
     }
 

--- a/code_files/R/bo_loop.R
+++ b/code_files/R/bo_loop.R
@@ -64,7 +64,11 @@ run_bo <- function(objective, method, cfg, X_init, y_init) {
       # is all but exhausted -- which.max still returns a point; a duplicate
       # then costs one iteration, it does not break the loop.)
       score[min_sqdist(canonicalize(X_cand, schema), X_seen) <= cfg$dup_tol^2] <- -Inf
-      x_next <- X_cand[which.max(score), , drop = FALSE]
+      # Break score ties at random. Exact ties are common early on (a flat
+      # posterior makes EI constant across candidates); always taking the
+      # first index would silently bias picks toward the pool's first row.
+      top    <- which(score == max(score))
+      x_next <- X_cand[if (length(top) > 1L) sample(top, 1L) else top, , drop = FALSE]
     }
 
     # Evaluate the (expensive) objective and record progress.

--- a/code_files/R/candidates.R
+++ b/code_files/R/candidates.R
@@ -18,11 +18,17 @@
 # incumbent's level and its index-neighbours -- which is meaningless for an
 # unordered factor (and actively wrong when the levels are permuted, as in
 # Cat-Ackley). So when an objective supplies a `schema`, the local half instead
-# makes Hamming-local moves on the categorical coordinates: it keeps most of them
-# at the incumbent's level and flips a small random subset to uniformly-random
-# *other* levels. Continuous coordinates still get the Gaussian cloud, so mixed
-# problems get a sensible joint local move. This generator is shared by BASS-BO
-# and GP-BO, so the surrogate remains the only thing that differs between them.
+# makes Hamming-local moves on the categorical coordinates: each coordinate keeps
+# the incumbent's level or flips to a uniformly-random *other* level with
+# probability 1/n_cat (a derived rate, not a knob). Crucially, on MIXED problems
+# a local row may keep the ENTIRE incumbent combination and only nudge the
+# continuous coordinates -- that pure continuous refinement at the best-known
+# combination is the main local-exploitation move BO has over Random Search, and
+# an always-flip rule forbids it (which measurably capped func2C/func3C; see
+# 3_categorical_diagnostics/). On purely categorical problems a zero-flip row
+# would just duplicate the incumbent, so there at least one flip is forced.
+# Continuous coordinates still get the Gaussian cloud. This generator is shared
+# by BASS-BO and GP-BO, so the surrogate remains the only thing that differs.
 #
 # Pure functions -- easy to unit-test.
 # =============================================================================
@@ -88,9 +94,13 @@ local_scale <- function(X_eval, best_idx) {
 
 #' Replace the categorical coordinates of a local cloud with Hamming-local moves.
 #'
-#' Each row keeps the incumbent's level on most categorical coordinates and flips
-#' a small random subset (1..min(3, #cat)) to uniformly-random *other* levels --
-#' the correct notion of "nearby" for an unordered factor. Chosen levels are
+#' Each row keeps the incumbent's level on most categorical coordinates: every
+#' coordinate flips to a uniformly-random *other* level independently with
+#' probability 1/#cat (so one flip in expectation) -- the correct notion of
+#' "nearby" for an unordered factor. On mixed schemas a row may flip NOTHING,
+#' keeping the incumbent's full combination so its continuous coordinates get a
+#' pure local refinement; on purely categorical schemas a zero-flip row would
+#' only duplicate the incumbent, so one flip is forced there. Chosen levels are
 #' written back as bin centres, `(level - 0.5) / L`, which decode exactly to that
 #' level (see decode_levels) and dedupe cleanly across iterations. Continuous
 #' coordinates in `X_local` are left untouched.
@@ -101,14 +111,17 @@ local_scale <- function(X_eval, best_idx) {
 #' @param cat_idx Integer indices of the categorical coordinates.
 #' @return        `X_local` with its categorical columns rewritten.
 local_categorical_moves <- function(X_local, x_best, schema, cat_idx) {
-  n_cat   <- length(cat_idx)
-  inc_lev <- vapply(cat_idx,
-                    function(j) as.integer(decode_levels(x_best[j], schema$levels[j])),
-                    integer(1))
+  n_cat    <- length(cat_idx)
+  pure_cat <- all(schema$types == "cat")
+  inc_lev  <- vapply(cat_idx,
+                     function(j) as.integer(decode_levels(x_best[j], schema$levels[j])),
+                     integer(1))
 
   for (r in seq_len(nrow(X_local))) {
-    k    <- sample.int(min(3L, n_cat), 1L)   # how many coords to flip (>= 1)
-    flip <- sample.int(n_cat, k)             # which categorical coords to flip
+    flip <- which(runif(n_cat) < 1 / n_cat)  # each coord flips w.p. 1/n_cat
+    if (pure_cat && length(flip) == 0L) {
+      flip <- sample.int(n_cat, 1L)          # zero flips = duplicate incumbent
+    }
     for (c in seq_len(n_cat)) {
       j   <- cat_idx[c]
       L   <- schema$levels[j]

--- a/code_files/R/candidates.R
+++ b/code_files/R/candidates.R
@@ -33,6 +33,32 @@
 # Pure functions -- easy to unit-test.
 # =============================================================================
 
+#' Canonical representation of points for duplicate detection.
+#'
+#' Two points whose categorical coordinates decode to the same levels are the
+#' SAME input to the objective, whatever their raw [0,1] encodings. Snapping
+#' each categorical coordinate to its bin centre `(level - 0.5) / L` makes such
+#' points exactly equal, so the ordinary Euclidean duplicate checks below work
+#' at the decoded-combination level: on a purely categorical problem a
+#' "duplicate" is a revisited combination, and on a mixed problem it is the
+#' same combination with (near-)identical continuous coordinates. Without this,
+#' the loop happily re-evaluates combinations it has already measured -- pure
+#' waste on a deterministic objective (instrumented runs showed ~2/3 of the
+#' budget lost to revisits on a small categorical benchmark).
+#'
+#' @param X      n x d matrix of points in [0,1]^d.
+#' @param schema Optional input schema (see objective_utils.R); NULL = identity.
+#' @return       n x d matrix with categorical columns snapped to bin centres.
+canonicalize <- function(X, schema = NULL) {
+  X <- as.matrix(X)
+  if (is.null(schema)) return(X)
+  for (j in which(schema$types == "cat")) {
+    L <- schema$levels[j]
+    X[, j] <- (decode_levels(X[, j], L) - 0.5) / L
+  }
+  X
+}
+
 #' Is point `x` already (almost) present in the rows of `X`?
 #'
 #' @param x   Numeric vector, the candidate point.

--- a/code_files/R/config.R
+++ b/code_files/R/config.R
@@ -18,6 +18,7 @@ default_config <- function() {
     # ---- Experiment ----
     objective  = "branin",  # which objective to optimise (see objectives/)
     d          = 2,         # input dimension
+    cat_L      = 11L,       # levels per categorical input (cat_ackley only; odd)
     budget     = 80,        # BO iterations after the initial design
     n_cand     = 1000,      # candidate points scored per iteration
     reps       = 10,        # independent repetitions (seeds)

--- a/code_files/R/experiment.R
+++ b/code_files/R/experiment.R
@@ -26,7 +26,7 @@
 #'             method/acquisition knobs).
 #' @return Long tibble with columns: seed, iter, method, best.
 run_one_seed <- function(seed, cfg) {
-  objective <- load_objective(cfg$objective, cfg$d)
+  objective <- load_objective(cfg$objective, cfg$d, cfg$cat_L)
   methods   <- make_methods(cfg, objective$schema)
 
   set.seed(seed)

--- a/code_files/R/experiment.R
+++ b/code_files/R/experiment.R
@@ -109,10 +109,61 @@ summarise_final <- function(all_runs) {
     dplyr::arrange(mean_final)
 }
 
+#' Paired per-seed comparison of every method against a baseline.
+#'
+#' Every method runs from the SAME initial design on each seed, so the design
+#' is paired -- and paired comparisons are what the unpaired mean +/- SD in
+#' `summarise_final()` throws away. Final bests are skewed minima; a method can
+#' trail on the mean yet win most seeds (or vice versa), so per-seed win/tie/
+#' loss counts against the baseline plus a Wilcoxon signed-rank test give the
+#' honest headline. Medians are reported alongside for the same reason.
+#'
+#' @param all_runs Long tibble from `run_experiment()` (and friends).
+#' @param baseline Method name to compare against (default "Random").
+#' @return Tibble with one row per non-baseline method: wins/ties/losses vs the
+#'   baseline, median finals, and the paired Wilcoxon p-value. Empty if the
+#'   baseline is absent.
+summarise_paired <- function(all_runs, baseline = "Random") {
+  finals <- all_runs |>
+    dplyr::group_by(seed, method) |>
+    dplyr::filter(iter == max(iter)) |>
+    dplyr::ungroup() |>
+    dplyr::select(seed, method, best)
+
+  if (!baseline %in% finals$method) return(finals[0, ])
+
+  base <- finals |>
+    dplyr::filter(method == baseline) |>
+    dplyr::select(seed, base_best = best)
+
+  finals |>
+    dplyr::filter(method != baseline) |>
+    dplyr::inner_join(base, by = "seed") |>
+    dplyr::group_by(method) |>
+    dplyr::summarise(
+      baseline        = baseline,
+      n_seeds         = dplyr::n(),
+      wins            = sum(best < base_best),
+      ties            = sum(best == base_best),
+      losses          = sum(best > base_best),
+      median_final    = median(best),
+      median_baseline = median(base_best),
+      # exact = FALSE: final bests can tie across methods (zero differences),
+      # which the exact distribution cannot handle. NA if the test is
+      # degenerate (e.g. every seed tied).
+      p_wilcoxon = tryCatch(
+        stats::wilcox.test(best, base_best, paired = TRUE, exact = FALSE)$p.value,
+        error = function(e) NA_real_),
+      .groups = "drop"
+    ) |>
+    dplyr::arrange(dplyr::desc(wins))
+}
+
 #' Write all CSVs and the convergence plot for an experiment.
 #'
 #' Produces, in `cfg$out_dir`: all_runs.csv, summary_curve.csv,
-#' final_summary.csv and convergence_mean_ci.png.
+#' final_summary.csv, paired_vs_random.csv (when a Random baseline is present)
+#' and convergence_mean_ci.png.
 #'
 #' @param all_runs  Long tibble from `run_experiment()`.
 #' @param objective Objective list (used for plot labels).
@@ -123,10 +174,14 @@ save_results <- function(all_runs, objective, cfg) {
 
   summary_curve <- summarise_curve(all_runs)
   final_summary <- summarise_final(all_runs)
+  paired        <- summarise_paired(all_runs)
 
   readr::write_csv(all_runs,      file.path(cfg$out_dir, "all_runs.csv"))
   readr::write_csv(summary_curve, file.path(cfg$out_dir, "summary_curve.csv"))
   readr::write_csv(final_summary, file.path(cfg$out_dir, "final_summary.csv"))
+  if (nrow(paired)) {
+    readr::write_csv(paired, file.path(cfg$out_dir, "paired_vs_random.csv"))
+  }
 
   p <- ggplot2::ggplot(
     summary_curve,

--- a/code_files/R/objectives.R
+++ b/code_files/R/objectives.R
@@ -19,15 +19,20 @@
 
 #' Load a named objective at a given dimension.
 #'
-#' @param name One of "branin", "rastrigin", "synthetic", "func2C", "func3C",
-#'             "cat_ackley".
-#' @param d    Input dimension. Branin is fixed at 2; Rastrigin and synthetic
-#'             accept any d >= 1. func2C/func3C have a fixed structure (d = 4 / 5)
-#'             and ignore `d` with a warning if it disagrees; cat_ackley uses `d`
-#'             as the number of categorical inputs.
-#' @return     A `list(name, d, fn, schema)` objective. `schema` is NULL for the
-#'             continuous benchmarks.
-load_objective <- function(name, d) {
+#' @param name  One of "branin", "rastrigin", "synthetic", "func2C", "func3C",
+#'              "cat_ackley".
+#' @param d     Input dimension. Branin is fixed at 2; Rastrigin and synthetic
+#'              accept any d >= 1. func2C/func3C have a fixed structure (d = 4 / 5)
+#'              and ignore `d` with a warning if it disagrees; cat_ackley uses `d`
+#'              as the number of categorical inputs.
+#' @param cat_L Levels per categorical input, cat_ackley only (odd; see
+#'              make_cat_ackley). NULL falls back to the classic 11, so the size
+#'              of the categorical space (L^d) is a protocol choice: d=3/L=5 is
+#'              solvable within a thesis budget, d=6/L=11 is the hard regime.
+#' @return      A `list(name, d, fn, schema)` objective. `schema` is NULL for the
+#'              continuous benchmarks.
+load_objective <- function(name, d, cat_L = NULL) {
+  if (is.null(cat_L)) cat_L <- 11L
   # Continuous benchmarks: a function plus a NULL schema.
   cont <- function(fn) list(name = name, d = d, fn = fn, schema = NULL)
 
@@ -62,7 +67,7 @@ load_objective <- function(name, d) {
            levels = c(3L, 5L, 4L, NA, NA)),
       nat_d = 5L),
     "cat_ackley" = {
-      ca <- make_cat_ackley(d)
+      ca <- make_cat_ackley(d, L = as.integer(cat_L))
       list(name = name, d = ca$d, fn = ca$fn, schema = ca$schema,
            opt_levels = ca$opt_levels)
     },

--- a/code_files/R/surrogates.R
+++ b/code_files/R/surrogates.R
@@ -99,6 +99,15 @@ make_bass_acquire <- function(cfg, schema = NULL) {
     X_eval <- as.matrix(X_eval)
     n_cand <- nrow(as.matrix(X_cand))
 
+    # .samples_by_cand() tells the two predict() orientations apart by the
+    # candidate count; a square draws-by-candidates matrix would be ambiguous.
+    if (n_cand == BASS_KEEP) {
+      stop(sprintf(paste0("n_cand (%d) equals the number of stored BASS ",
+                          "posterior draws; the predict() orientation check ",
+                          "cannot disambiguate a square matrix. Pick a ",
+                          "different --n_cand."), n_cand))
+    }
+
     # Standardise y for BASS's numerics; guard a zero spread.
     y_mean <- mean(y_eval)
     y_sd   <- sd(y_eval)
@@ -150,6 +159,11 @@ make_gp_acquire <- function(cfg) {
     fit <- tryCatch(GPfit::GP_fit(X_eval, y_eval), error = function(e) NULL)
 
     if (is.null(fit)) {
+      # Say so: with a flat predictive, EI is constant and this iteration's
+      # pick is effectively random. Frequent fallbacks mean the GP-BO curve is
+      # partly a random-search curve, which the analysis should know about.
+      message(sprintf("GP-BO: GP_fit failed on n=%d points; flat predictive fallback.",
+                      nrow(as.matrix(X_eval))))
       y_spread <- sd(y_eval)
       if (!is.finite(y_spread) || y_spread < 1e-12) y_spread <- 1e-6
       mu <- rep(mean(y_eval), n_cand)

--- a/code_files/R/tpe.R
+++ b/code_files/R/tpe.R
@@ -145,7 +145,7 @@ run_tpe <- function(objective, cfg, X_init, y_init, seed, sampler_opts = list())
 #' @param cfg Config list (uses `objective`, `d`, `budget`, `reps`, `seed_start`).
 #' @return Long tibble with columns seed, iter, method ("TPE"), best.
 run_tpe_experiment <- function(cfg) {
-  objective <- load_objective(cfg$objective, cfg$d)
+  objective <- load_objective(cfg$objective, cfg$d, cfg$cat_L)
   d  <- objective$d
   n0 <- max(2 * d + 1, 8)
   seeds <- cfg$seed_start + 0:(cfg$reps - 1)
@@ -180,7 +180,7 @@ run_tpe_experiment <- function(cfg) {
 #' @return Long tibble with columns seed, iter, method (one of `names(configs)`),
 #'   best.
 run_tpe_sweep_experiment <- function(cfg, configs) {
-  objective <- load_objective(cfg$objective, cfg$d)
+  objective <- load_objective(cfg$objective, cfg$d, cfg$cat_L)
   d  <- objective$d
   n0 <- max(2 * d + 1, 8)
   seeds <- cfg$seed_start + 0:(cfg$reps - 1)

--- a/code_files/run_all_final.sh
+++ b/code_files/run_all_final.sh
@@ -37,7 +37,14 @@ Rscript run_benchmark.R --objective=synthetic  --d=3 --budget="$BUDGET" --reps="
 # --- Categorical / mixed benchmarks (TPE is the strongest comparison here) ---
 Rscript run_benchmark.R --objective=func2C            --budget="$BUDGET" --reps="$REPS" --with_tpe="$WITH_TPE"
 Rscript run_benchmark.R --objective=func3C            --budget="$BUDGET" --reps="$REPS" --with_tpe="$WITH_TPE"
-Rscript run_benchmark.R --objective=cat_ackley --d=6 --budget="$BUDGET" --reps="$REPS" --with_tpe="$WITH_TPE"
+# Cat-Ackley at three sizes (L^d combinations). The easy instance (125) is
+# solvable within the budget and demonstrates the categorical capability
+# decisively; the medium (2401) and hard (1.77M) instances show how the edge
+# behaves as the space outgrows the budget. Results land in
+# results/cat_ackley_d{d}_L{L}/.
+Rscript run_benchmark.R --objective=cat_ackley --d=3 --cat_L=5  --budget="$BUDGET" --reps="$REPS" --with_tpe="$WITH_TPE"
+Rscript run_benchmark.R --objective=cat_ackley --d=4 --cat_L=7  --budget="$BUDGET" --reps="$REPS" --with_tpe="$WITH_TPE"
+Rscript run_benchmark.R --objective=cat_ackley --d=6 --cat_L=11 --budget="$BUDGET" --reps="$REPS" --with_tpe="$WITH_TPE"
 
 # --- TPE gamma-sensitivity ablation (branin + cat_ackley) --------------------
 Rscript 2_tpe_sensitivity/run_tpe_sensitivity.R --budget="$BUDGET" --reps="$REPS"

--- a/code_files/run_benchmark.R
+++ b/code_files/run_benchmark.R
@@ -46,17 +46,24 @@ source_library(lib_dir)
 # --- Configuration ------------------------------------------------------------
 cfg <- parse_cli_args(commandArgs(trailingOnly = TRUE))
 
+# The objective and methods are rebuilt from `cfg` inside each parallel worker
+# (see run_one_seed), so we only build a copy here for the result labels/plots.
+objective <- load_objective(cfg$objective, cfg$d, cfg$cat_L)
+
 # Keep the results root tidy: give every objective its own subfolder, so runs on
 # different objectives accumulate side by side instead of overwriting each other.
-cfg$out_dir <- file.path(cfg$out_dir, cfg$objective)
+# cat_ackley's difficulty is set by (d, L), so those go into the folder name --
+# the easy and hard instances are different benchmarks and must not overwrite
+# one another.
+run_label <- if (cfg$objective == "cat_ackley") {
+  sprintf("cat_ackley_d%d_L%d", objective$d, cfg$cat_L)
+} else {
+  cfg$objective
+}
+cfg$out_dir <- file.path(cfg$out_dir, run_label)
 
 # --- Parallel backend: one worker per core, leaving one free -----------------
 plan(multisession, workers = max(1L, parallel::detectCores() - 1L))
-
-# --- Run the experiment -------------------------------------------------------
-# The objective and methods are rebuilt from `cfg` inside each parallel worker
-# (see run_one_seed), so we only build a copy here for the result labels/plots.
-objective <- load_objective(cfg$objective, cfg$d)
 
 cat(sprintf("Running %s (d=%d) | budget=%d | reps=%d\n",
             cfg$objective, objective$d, cfg$budget, cfg$reps))

--- a/code_files/run_benchmark.R
+++ b/code_files/run_benchmark.R
@@ -86,6 +86,16 @@ final_summary <- save_results(all_runs, objective, cfg)
 
 # --- Report -------------------------------------------------------------------
 print(final_summary)
+
+# Paired per-seed comparison vs Random (shared initial designs make the design
+# paired; win counts + a signed-rank test are more informative than the means).
+paired <- summarise_paired(all_runs)
+if (nrow(paired)) {
+  cat("\nPaired per-seed comparison vs Random (wins = seeds with a strictly",
+      "better final best):\n")
+  print(paired)
+}
+
 cat(sprintf("\nArtifacts saved in: %s\n", normalizePath(cfg$out_dir)))
 
 # --- Shut down parallel workers so the process can exit -----------------------

--- a/code_files/tests/testthat/test-bo_loop.R
+++ b/code_files/tests/testthat/test-bo_loop.R
@@ -52,6 +52,37 @@ test_that("Random Search runs and never gets worse", {
   expect_true(all(diff(best) <= 0))
 })
 
+test_that("no method re-evaluates a categorical combination (combo-level dedup)", {
+  set.seed(11)
+  ca  <- make_cat_ackley(3L, L = 5L)               # 125 combinations
+  obj <- list(name = "cat_ackley_small", d = ca$d, fn = ca$fn, schema = ca$schema)
+
+  cfg <- tiny_cfg(budget = 25, n_cand = 300)
+
+  combo_of <- function(X) apply(canonicalize(X, obj$schema), 1, paste, collapse = "|")
+
+  # Oracle-guided loop (EI would exercise BASS; the dedup path is the same).
+  oracle <- list(
+    name       = "oracle",
+    candidates = function(X_eval, y_eval)
+      hybrid_candidates(X_eval, y_eval, cfg$n_cand, obj$schema),
+    acquire    = function(X_eval, y_eval, X_cand) -obj$fn(X_cand)
+  )
+  rnd <- make_methods(cfg, obj$schema)[["Random"]]
+
+  X_init <- space_filling_candidates(8, obj$d)
+  y_init <- obj$fn(X_init)
+
+  for (m in list(oracle, rnd)) {
+    res    <- run_bo(obj, m, cfg, X_init, y_init)
+    combos <- combo_of(res$X)
+    # 8 + 25 = 33 evaluations over 125 combinations: every one must be fresh
+    # (the initial design may collide with itself; the loop's picks must not).
+    picks  <- combos[(nrow(X_init) + 1):length(combos)]
+    expect_false(any(picks %in% combos[1:nrow(X_init)]) || anyDuplicated(picks) > 0)
+  }
+})
+
 test_that("real BASS (EI and Thompson) and GP run end to end (if installed)", {
   skip_if_not_installed("BASS")
   skip_if_not_installed("GPfit")

--- a/code_files/tests/testthat/test-candidates.R
+++ b/code_files/tests/testthat/test-candidates.R
@@ -10,6 +10,23 @@ test_that("min_sqdist returns the nearest squared distance per candidate", {
   expect_equal(d2[2], 0.5)    # equidistant from both corners: 0.25 + 0.25
 })
 
+test_that("canonicalize equates encodings that decode to the same combination", {
+  schema <- list(types = c("cat", "cont"), levels = c(4L, NA))
+  # Both rows decode the categorical coordinate to level 2 (u in [0.25, 0.5)).
+  X <- rbind(c(0.26, 0.7),
+             c(0.49, 0.7))
+  Xc <- canonicalize(X, schema)
+  expect_equal(Xc[1, ], Xc[2, ])              # same combination -> same row
+  expect_equal(Xc[, 1], rep((2 - 0.5) / 4, 2)) # snapped to the bin centre
+  expect_equal(Xc[, 2], X[, 2])                # continuous coords untouched
+
+  # Different levels stay distinct; NULL schema is the identity.
+  X2 <- rbind(c(0.1, 0.7), c(0.9, 0.7))
+  expect_false(isTRUE(all.equal(canonicalize(X2, schema)[1, 1],
+                                canonicalize(X2, schema)[2, 1])))
+  expect_equal(canonicalize(X, NULL), as.matrix(X))
+})
+
 test_that("is_duplicate flags near points and ignores far ones", {
   X <- matrix(c(0.1, 0.1,
                 0.9, 0.9), ncol = 2, byrow = TRUE)

--- a/code_files/tests/testthat/test-candidates.R
+++ b/code_files/tests/testthat/test-candidates.R
@@ -53,13 +53,41 @@ test_that("schema-aware local half makes Hamming-local categorical moves", {
   # Categorical coords sit on bin centres, so they decode back exactly.
   expect_true(all(abs(local_rows * L - (floor(local_rows * L) + 0.5)) < 1e-9))
 
-  # Every local move differs from the incumbent in 1..3 coordinates (Hamming-local).
+  # Purely categorical schema: every local move differs from the incumbent in at
+  # least one coordinate (a zero-flip row would just duplicate the incumbent),
+  # and stays Hamming-local (about one flip in expectation, never all coords).
   ham <- rowSums(sweep(levs, 2, inc, "!=") != 0)
-  expect_true(all(ham >= 1 & ham <= 3))
+  expect_true(all(ham >= 1))
+  expect_lt(mean(ham), 3)
 
   # Flips can reach non-adjacent levels (not just index neighbours): some coord
   # should land more than one level away from the incumbent at least once.
   expect_true(any(abs(sweep(levs, 2, inc, "-")) > 1))
+})
+
+test_that("mixed-schema local rows can KEEP the incumbent's full combination", {
+  set.seed(3)
+  # Two categorical + two continuous, like Func-2C.
+  schema <- list(types = c("cat", "cat", "cont", "cont"),
+                 levels = c(3L, 5L, NA, NA))
+  X_eval <- matrix(runif(12 * 4), ncol = 4)
+  y_eval <- runif(12)
+  n_cand <- 400
+  X <- hybrid_candidates(X_eval, y_eval, n_cand = n_cand, schema = schema)
+
+  inc <- decode_levels(X_eval[which.min(y_eval), 1:2], c(3L, 5L))
+  n_local <- floor(n_cand / 2)
+  local_rows <- X[(n_cand - n_local + 1):n_cand, , drop = FALSE]
+  levs <- cbind(decode_levels(local_rows[, 1], 3L), decode_levels(local_rows[, 2], 5L))
+  ham  <- rowSums(sweep(levs, 2, inc, "!=") != 0)
+
+  # A substantial fraction of local rows keep the incumbent's combination, so
+  # the continuous coordinates get refined at the best-known combination --
+  # the local-exploitation move that an always-flip rule forbids. With flip
+  # probability 1/2 per coordinate, ~25% of rows keep both levels.
+  expect_gt(mean(ham == 0), 0.10)
+  # ... and a substantial fraction still explore other combinations.
+  expect_gt(mean(ham >= 1), 0.50)
 })
 
 test_that("hybrid_candidates leaves continuous coords Gaussian under a mixed schema", {

--- a/code_files/tests/testthat/test-categorical.R
+++ b/code_files/tests/testthat/test-categorical.R
@@ -100,6 +100,13 @@ test_that("load_objective returns schema + fixed dimensions for the new benchmar
   oc <- load_objective("cat_ackley", 6)
   expect_equal(oc$d, 6)
   expect_true(all(oc$schema$types == "cat"))
+  expect_equal(oc$schema$levels, rep(11L, 6))   # classic default preserved
+
+  # cat_L controls the instance size (the easy/medium/hard protocol knob).
+  oe <- load_objective("cat_ackley", 3, cat_L = 5L)
+  expect_equal(oe$schema$levels, rep(5L, 3))
+  expect_equal(oe$fn(matrix((oe$opt_levels - 0.5) / 5, nrow = 1)), 0,
+               tolerance = 1e-9)
 
   # Continuous benchmarks still carry a NULL schema.
   expect_null(load_objective("branin", 2)$schema)

--- a/code_files/tests/testthat/test-experiment.R
+++ b/code_files/tests/testthat/test-experiment.R
@@ -12,6 +12,35 @@
 # failure. A forked (multicore) worker would inherit the parent's globals and
 # silently mask it.
 
+test_that("summarise_paired counts per-seed wins against the baseline", {
+  skip_if_not_installed("dplyr")
+
+  # 4 seeds, 2 iterations; final bests are at iter == 2.
+  toy <- function(method, finals) {
+    dplyr::bind_rows(lapply(seq_along(finals), function(s) {
+      tibble::tibble(seed = s, iter = 0:2, method = method,
+                     best = c(1, 0.9, finals[s]))
+    }))
+  }
+  runs <- dplyr::bind_rows(
+    toy("BASS-BO", c(0.1, 0.2, 0.5, 0.3)),   # beats Random on seeds 1, 2, 4
+    toy("Random",  c(0.4, 0.4, 0.4, 0.4)),
+    toy("GP-BO",   c(0.4, 0.5, 0.6, 0.7))    # one tie, three losses
+  )
+
+  p <- summarise_paired(runs)
+  expect_setequal(p$method, c("BASS-BO", "GP-BO"))
+
+  bass <- p[p$method == "BASS-BO", ]
+  expect_equal(c(bass$wins, bass$ties, bass$losses), c(3, 0, 1))
+  gp <- p[p$method == "GP-BO", ]
+  expect_equal(c(gp$wins, gp$ties, gp$losses), c(0, 1, 3))
+
+  expect_true(all(is.finite(p$median_final)))
+  # Baseline absent -> empty result, not an error.
+  expect_equal(nrow(summarise_paired(runs[runs$method != "Random", ])), 0)
+})
+
 test_that("a rebuilt benchmark objective evaluates on a fresh parallel worker", {
   skip_if_not_installed("furrr")
   skip_if_not_installed("future")

--- a/run_on_ec2.sh
+++ b/run_on_ec2.sh
@@ -435,7 +435,10 @@ run_suite() {
   # Categorical / mixed benchmarks (TPE is the strongest comparison here).
   run_step "bench-func2C"     Rscript run_benchmark.R --objective=func2C            --budget="$BUDGET" --reps="$REPS" --with_tpe="$WITH_TPE"
   run_step "bench-func3C"     Rscript run_benchmark.R --objective=func3C            --budget="$BUDGET" --reps="$REPS" --with_tpe="$WITH_TPE"
-  run_step "bench-cat_ackley" Rscript run_benchmark.R --objective=cat_ackley --d=6 --budget="$BUDGET" --reps="$REPS" --with_tpe="$WITH_TPE"
+  # Cat-Ackley at three sizes: easy (5^3) / medium (7^4) / hard (11^6).
+  run_step "bench-cat_ackley-easy" Rscript run_benchmark.R --objective=cat_ackley --d=3 --cat_L=5  --budget="$BUDGET" --reps="$REPS" --with_tpe="$WITH_TPE"
+  run_step "bench-cat_ackley-med"  Rscript run_benchmark.R --objective=cat_ackley --d=4 --cat_L=7  --budget="$BUDGET" --reps="$REPS" --with_tpe="$WITH_TPE"
+  run_step "bench-cat_ackley-hard" Rscript run_benchmark.R --objective=cat_ackley --d=6 --cat_L=11 --budget="$BUDGET" --reps="$REPS" --with_tpe="$WITH_TPE"
   # TPE gamma-sensitivity ablation (Branin + Cat-Ackley).
   run_step "tpe-sensitivity"  Rscript 2_tpe_sensitivity/run_tpe_sensitivity.R --budget="$BUDGET" --reps="$REPS"
   # Elastic Net case study.

--- a/run_on_ec2.sh
+++ b/run_on_ec2.sh
@@ -2,8 +2,8 @@
 # =============================================================================
 # run_on_ec2.sh  --  One-shot, self-contained runner for a remote Linux box
 # =============================================================================
-# Provisions a fresh Linux EC2 instance, clones the repo (branch with the
-# categorical candidate-generation fix), and runs EVERYTHING we need in one go:
+# Provisions a fresh Linux EC2 instance, clones the repo (BRANCH defaults to the
+# consolidated fixes branch; override with BRANCH=...), and runs EVERYTHING in one go:
 #
 #   1. The full thesis benchmark suite (continuous + categorical + TPE
 #      sensitivity + Elastic Net), exactly the headline protocol.
@@ -46,7 +46,7 @@ set -uo pipefail
 
 # --- Configuration (all env-overridable) -------------------------------------
 REPO_URL="${REPO_URL:-https://github.com/AdrianTJ/BayesianOptim_BASS.git}"
-BRANCH="${BRANCH:-claude/categorical-candidates}"
+BRANCH="${BRANCH:-claude/bass-bo-benchmark-review-hnxikv}"
 LOCAL_REPO="${LOCAL_REPO:-}"          # if set, copy from here instead of cloning
 GITHUB_TOKEN="${GITHUB_TOKEN:-}"      # for private https clone
 WORKDIR="${WORKDIR:-$HOME/bass-run}"

--- a/run_on_ec2.sh
+++ b/run_on_ec2.sh
@@ -1,0 +1,481 @@
+#!/usr/bin/env bash
+# =============================================================================
+# run_on_ec2.sh  --  One-shot, self-contained runner for a remote Linux box
+# =============================================================================
+# Provisions a fresh Linux EC2 instance, clones the repo (branch with the
+# categorical candidate-generation fix), and runs EVERYTHING we need in one go:
+#
+#   1. The full thesis benchmark suite (continuous + categorical + TPE
+#      sensitivity + Elastic Net), exactly the headline protocol.
+#   2. An extensive BASS "why does it trail on categoricals?" investigation:
+#      acquisition (EI vs Thompson) x posterior resolution (fast vs rich MCMC)
+#      x evaluation budget (read off a single long run) x objective and
+#      categorical dimension. GP-BO and Random are run as references.
+#
+# All CSVs, plots, logs, package versions, hardware info and timings are
+# collected under one results tree and tar-gzipped at the end for download.
+#
+# -----------------------------------------------------------------------------
+# TESTED TARGET: Ubuntu 22.04 / 24.04 (the common EC2 AMIs). A best-effort
+# Amazon Linux / RHEL (dnf) path is included but Ubuntu is first-class.
+#
+# RECOMMENDED INSTANCE: compute-optimised with many vCPUs and >=16 GB RAM,
+# e.g. c6i.8xlarge (32 vCPU) or c6i.16xlarge (64 vCPU). Seeds fan out across
+# cores, so wall-clock scales almost linearly with vCPU count. Rough guide at
+# the defaults below on 32 vCPU: full suite ~1-2 h, diagnostics ~3-6 h.
+#
+# -----------------------------------------------------------------------------
+# USAGE
+#   # Private repo (default): supply a GitHub token with 'repo' scope.
+#   GITHUB_TOKEN=ghp_xxx bash run_on_ec2.sh
+#
+#   # ...or if you scp'd the repo onto the box already:
+#   LOCAL_REPO=$HOME/BayesianOptim_BASS bash run_on_ec2.sh
+#
+#   # Validate the whole pipeline end-to-end in ~10 min before the real run:
+#   SMOKE=1 GITHUB_TOKEN=ghp_xxx bash run_on_ec2.sh
+#
+#   # Skip parts (e.g. environment already set up):
+#   RUN_SETUP=0 GITHUB_TOKEN=ghp_xxx bash run_on_ec2.sh
+#
+# Run it under tmux/screen (or nohup) so an SSH drop doesn't kill the job:
+#   tmux new -s bass 'GITHUB_TOKEN=ghp_xxx bash run_on_ec2.sh; bash'
+# =============================================================================
+
+set -uo pipefail
+
+# --- Configuration (all env-overridable) -------------------------------------
+REPO_URL="${REPO_URL:-https://github.com/AdrianTJ/BayesianOptim_BASS.git}"
+BRANCH="${BRANCH:-claude/categorical-candidates}"
+LOCAL_REPO="${LOCAL_REPO:-}"          # if set, copy from here instead of cloning
+GITHUB_TOKEN="${GITHUB_TOKEN:-}"      # for private https clone
+WORKDIR="${WORKDIR:-$HOME/bass-run}"
+
+# Headline benchmark protocol (matches the thesis: budget 80, 25 seeds).
+REPS="${REPS:-25}"
+BUDGET="${BUDGET:-80}"
+WITH_TPE="${WITH_TPE:-true}"
+ENET_REPS="${ENET_REPS:-50}"
+ENET_BUDGET="${ENET_BUDGET:-100}"
+
+# Diagnostics protocol. DIAG_BUDGET is run once and sliced at 80 & DIAG_BUDGET,
+# so the evaluation-budget axis is free.
+DIAG_REPS="${DIAG_REPS:-20}"
+DIAG_BUDGET="${DIAG_BUDGET:-160}"
+# "rich" posterior resolution for BASS (default fast is 4000/2000/10 from the lib).
+export DIAG_RICH_NMCMC="${DIAG_RICH_NMCMC:-12000}"
+export DIAG_RICH_NBURN="${DIAG_RICH_NBURN:-6000}"
+export DIAG_RICH_THIN="${DIAG_RICH_THIN:-10}"
+export DIAG_INCLUDE_FULL="${DIAG_INCLUDE_FULL:-1}"    # cat_ackley d6 + func3C, all 4 BASS variants
+export DIAG_INCLUDE_LIGHT="${DIAG_INCLUDE_LIGHT:-1}"  # cat_ackley d4/d8 + func2C, EI variants only
+
+# Stage toggles.
+RUN_SETUP="${RUN_SETUP:-1}"
+RUN_SUITE="${RUN_SUITE:-1}"
+RUN_DIAG="${RUN_DIAG:-1}"
+
+# SMOKE=1 shrinks everything for a fast end-to-end validation.
+if [ "${SMOKE:-0}" = "1" ]; then
+  REPS=2; BUDGET=8; ENET_REPS=2; ENET_BUDGET=6
+  DIAG_REPS=2; DIAG_BUDGET=12
+  export DIAG_RICH_NMCMC=2000 DIAG_RICH_NBURN=1000 DIAG_RICH_THIN=10
+fi
+
+# --- Plumbing ----------------------------------------------------------------
+mkdir -p "$WORKDIR"
+LOG="$WORKDIR/run.log"
+# Mirror all stdout/stderr to the run log.
+exec > >(tee -a "$LOG") 2>&1
+
+if [ "$(id -u)" -eq 0 ]; then SUDO=""; else SUDO="sudo"; fi
+
+ts()  { date +"%Y-%m-%dT%H:%M:%S%z"; }
+log() { echo ""; echo "[$(ts)] === $* ==="; }
+
+# run_step "name" cmd...  -- time it, log it, and KEEP GOING on failure so one
+# bad objective never throws away a multi-hour job. Records outcomes in STEPLOG.
+STEPLOG="$WORKDIR/steps.tsv"
+run_step() {
+  local name="$1"; shift
+  local start end rc
+  log "START: $name"
+  start=$(date +%s)
+  "$@"; rc=$?
+  end=$(date +%s)
+  printf '%s\t%s\t%ss\trc=%s\n' "$(ts)" "$name" "$((end-start))" "$rc" >> "$STEPLOG"
+  if [ "$rc" -ne 0 ]; then
+    log "FAILED (rc=$rc, ${name}) -- continuing"
+  else
+    log "OK ($((end-start))s): $name"
+  fi
+  return 0
+}
+
+log "Config: REPS=$REPS BUDGET=$BUDGET DIAG_REPS=$DIAG_REPS DIAG_BUDGET=$DIAG_BUDGET WITH_TPE=$WITH_TPE SMOKE=${SMOKE:-0}"
+log "WORKDIR=$WORKDIR"
+
+# =============================================================================
+# 1. System dependencies + R + Python
+# =============================================================================
+PKG_MGR="unknown"
+command -v apt-get >/dev/null 2>&1 && PKG_MGR="apt"
+command -v dnf     >/dev/null 2>&1 && PKG_MGR="${PKG_MGR/unknown/dnf}"
+command -v yum     >/dev/null 2>&1 && [ "$PKG_MGR" = "unknown" ] && PKG_MGR="yum"
+
+install_system_deps() {
+  if [ "$PKG_MGR" = "apt" ]; then
+    export DEBIAN_FRONTEND=noninteractive
+    $SUDO apt-get update -y
+    $SUDO apt-get install -y --no-install-recommends \
+      build-essential gfortran ca-certificates curl git \
+      r-base r-base-dev \
+      libcurl4-openssl-dev libssl-dev libxml2-dev \
+      libfontconfig1-dev libharfbuzz-dev libfribidi-dev \
+      libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev \
+      python3 python3-pip python3-venv
+  elif [ "$PKG_MGR" = "dnf" ] || [ "$PKG_MGR" = "yum" ]; then
+    echo "WARNING: non-apt system; this path is best-effort (Ubuntu is first-class)."
+    $SUDO "$PKG_MGR" install -y \
+      gcc gcc-c++ gcc-gfortran make git curl \
+      R R-devel \
+      libcurl-devel openssl-devel libxml2-devel \
+      fontconfig-devel harfbuzz-devel fribidi-devel \
+      freetype-devel libpng-devel libtiff-devel libjpeg-turbo-devel \
+      python3 python3-pip || true
+  else
+    echo "ERROR: no supported package manager (apt/dnf/yum) found."; return 1
+  fi
+}
+
+install_r_packages() {
+  # Use Posit Public Package Manager BINARY builds on Ubuntu -- this turns a
+  # ~40 min source compile of tidyverse et al. into a couple of minutes.
+  local codename="" repo="https://cloud.r-project.org"
+  if [ "$PKG_MGR" = "apt" ] && [ -r /etc/os-release ]; then
+    codename="$(. /etc/os-release; echo "${VERSION_CODENAME:-}")"
+    case "$codename" in
+      jammy|noble|focal|bookworm|bullseye)
+        repo="https://packagemanager.posit.co/cran/__linux__/${codename}/latest" ;;
+    esac
+  fi
+  echo "R package repo: $repo"
+  Rscript --no-save - "$repo" <<'R_EOF'
+args <- commandArgs(trailingOnly = TRUE)
+repo <- args[[1]]
+# Make PPM serve binaries matched to this R/distro.
+options(
+  repos = c(CRAN = repo),
+  HTTPUserAgent = sprintf(
+    "R/%s R (%s)", getRversion(),
+    paste(getRversion(), R.version["platform"], R.version["arch"], R.version["os"])
+  ),
+  Ncpus = max(1L, parallel::detectCores())
+)
+pkgs <- c("tidyverse", "lhs", "BASS", "GPfit", "future", "furrr",
+          "testthat", "glmnet", "reticulate")  # MASS ships with R
+need <- pkgs[!vapply(pkgs, requireNamespace, logical(1), quietly = TRUE)]
+if (length(need)) {
+  cat("Installing:", paste(need, collapse = ", "), "\n")
+  install.packages(need)
+}
+miss <- pkgs[!vapply(pkgs, requireNamespace, logical(1), quietly = TRUE)]
+if (length(miss)) { cat("STILL MISSING:", paste(miss, collapse = ", "), "\n"); quit(status = 1) }
+cat("All R packages present.\n")
+R_EOF
+}
+
+install_python_optuna() {
+  local venv="$WORKDIR/optuna-venv"
+  if [ ! -x "$venv/bin/python" ]; then
+    python3 -m venv "$venv"
+  fi
+  "$venv/bin/pip" install --upgrade pip >/dev/null
+  "$venv/bin/pip" install "optuna>=3.4" numpy
+  # reticulate honours RETICULATE_PYTHON; make it visible to every R call below.
+  export RETICULATE_PYTHON="$venv/bin/python"
+  echo "RETICULATE_PYTHON=$RETICULATE_PYTHON"
+  "$venv/bin/python" -c "import optuna; print('optuna', optuna.__version__)"
+}
+
+if [ "$RUN_SETUP" = "1" ]; then
+  run_step "system-deps"   install_system_deps
+  run_step "r-packages"    install_r_packages
+  run_step "python-optuna" install_python_optuna
+else
+  # Still need reticulate pointed at optuna if the venv exists.
+  [ -x "$WORKDIR/optuna-venv/bin/python" ] && export RETICULATE_PYTHON="$WORKDIR/optuna-venv/bin/python"
+fi
+
+# =============================================================================
+# 2. Get the code
+# =============================================================================
+REPO_DIR="$WORKDIR/BayesianOptim_BASS"
+get_repo() {
+  rm -rf "$REPO_DIR"
+  if [ -n "$LOCAL_REPO" ]; then
+    echo "Copying from LOCAL_REPO=$LOCAL_REPO"
+    cp -a "$LOCAL_REPO" "$REPO_DIR"
+    git -C "$REPO_DIR" checkout "$BRANCH" || true
+  else
+    local url="$REPO_URL"
+    if [ -n "$GITHUB_TOKEN" ]; then
+      url="https://x-access-token:${GITHUB_TOKEN}@github.com/AdrianTJ/BayesianOptim_BASS.git"
+    fi
+    git clone --branch "$BRANCH" --single-branch "$url" "$REPO_DIR"
+  fi
+  echo "HEAD: $(git -C "$REPO_DIR" rev-parse HEAD)  ($(git -C "$REPO_DIR" rev-parse --abbrev-ref HEAD))"
+}
+run_step "get-repo" get_repo
+
+CODE_DIR="$REPO_DIR/code_files"
+RESULTS_DIR="$CODE_DIR/results"          # runners nest per-objective subfolders here
+mkdir -p "$RESULTS_DIR"
+
+# =============================================================================
+# 3. Write the BASS diagnostics driver into the repo (self-contained)
+# =============================================================================
+DRIVER="$CODE_DIR/run_bass_diagnostics.R"
+cat > "$DRIVER" <<'R_EOF'
+#!/usr/bin/env Rscript
+# Embedded by run_on_ec2.sh. Investigates WHY BASS-BO trails on categorical
+# problems, holding the (now schema-aware) candidate generator fixed.
+#
+# Matrix: BASS acquisition {EI, Thompson} x posterior resolution {fast, rich}
+# x evaluation budget (one long run, sliced at 80 and DIAG_BUDGET) x objective
+# and categorical dimension. GP-BO and Random are run once per objective as
+# references. Each (objective, seed) shares one initial design across methods.
+suppressPackageStartupMessages({
+  library(tidyverse); library(lhs); library(BASS); library(GPfit)
+  library(future); library(furrr)
+})
+
+this_file  <- sub("^--file=", "", grep("^--file=", commandArgs(FALSE), value = TRUE))
+script_dir <- if (length(this_file)) dirname(normalizePath(this_file)) else getwd()
+lib_dir    <- file.path(script_dir, "R")
+source(file.path(lib_dir, "bootstrap.R")); source_library(lib_dir)
+
+cfg0 <- parse_cli_args(commandArgs(trailingOnly = TRUE))   # --reps --budget --out_dir --n_cand ...
+DIAG_REPS   <- cfg0$reps
+DIAG_BUDGET <- cfg0$budget
+OUT         <- cfg0$out_dir
+dir.create(OUT, showWarnings = FALSE, recursive = TRUE)
+
+plan(multisession, workers = max(1L, parallel::detectCores() - 1L))
+
+# Posterior-resolution presets. "fast" matches the library default; "rich" is
+# tunable from the environment. Set as globals so furrr exports them per call.
+mcmc_presets <- list(
+  fast = c(nmcmc = 4000L, nburn = 2000L, thin = 10L),
+  rich = c(nmcmc = as.integer(Sys.getenv("DIAG_RICH_NMCMC", "12000")),
+           nburn = as.integer(Sys.getenv("DIAG_RICH_NBURN",  "6000")),
+           thin  = as.integer(Sys.getenv("DIAG_RICH_THIN",     "10")))
+)
+set_bass_mcmc <- function(p) {
+  assign("BASS_NMCMC", as.integer(p["nmcmc"]), envir = .GlobalEnv)
+  assign("BASS_NBURN", as.integer(p["nburn"]), envir = .GlobalEnv)
+  assign("BASS_THIN",  as.integer(p["thin"]),  envir = .GlobalEnv)
+  assign("BASS_KEEP",
+         (as.integer(p["nmcmc"]) - as.integer(p["nburn"])) %/% as.integer(p["thin"]),
+         envir = .GlobalEnv)
+}
+
+# Run a set of methods for one seed on one objective, from a shared design.
+run_seed_methods <- function(seed, objname, d, budget, method_specs, ncand, eps, duptol) {
+  objective <- load_objective(objname, d)
+  schema    <- objective$schema
+  set.seed(seed)
+  dd     <- objective$d
+  n0     <- max(2 * dd + 1, 8)
+  X_init <- lhs::maximinLHS(n0, dd)
+  y_init <- objective$fn(X_init)
+  cand   <- function(X, y) hybrid_candidates(X, y, ncand, schema)
+
+  rows <- list()
+  for (ms in method_specs) {
+    acq <- switch(ms$kind,
+      random = NULL,
+      gp     = make_gp_acquire(list(eps = eps)),
+      bass   = make_bass_acquire(list(acquisition = ms$acq), schema)
+    )
+    m   <- list(name = ms$label,
+                candidates = if (is.null(acq)) NULL else cand,
+                acquire = acq)
+    res <- run_bo(objective, m, list(budget = budget, dup_tol = duptol), X_init, y_init)
+    nm  <- if (identical(ms$kind, "bass")) BASS_NMCMC else NA_integer_   # verifies the override propagated
+    rows[[ms$label]] <- tibble::tibble(
+      objective = sprintf("%s_d%d", objname, dd),
+      seed = seed, iter = 0:budget, method = ms$label, best = res$best, nmcmc = nm
+    )
+  }
+  dplyr::bind_rows(rows)
+}
+
+# Objective grid. full = TRUE -> include Thompson variants (the harder cells).
+specs <- list(
+  list(name = "cat_ackley", d = 6L, full = TRUE),
+  list(name = "func3C",     d = 5L, full = TRUE),
+  list(name = "cat_ackley", d = 4L, full = FALSE),
+  list(name = "cat_ackley", d = 8L, full = FALSE),
+  list(name = "func2C",     d = 4L, full = FALSE)
+)
+if (Sys.getenv("DIAG_INCLUDE_FULL",  "1") != "1") specs <- Filter(function(s) !s$full, specs)
+if (Sys.getenv("DIAG_INCLUDE_LIGHT", "1") != "1") specs <- Filter(function(s)  s$full, specs)
+
+seeds <- cfg0$seed_start + 0:(DIAG_REPS - 1)
+fopts <- furrr::furrr_options(seed = TRUE, packages = c("BASS", "GPfit", "lhs"))
+
+run_objective <- function(spec) {
+  objname <- spec$name; d <- spec$d; full <- spec$full
+  cat(sprintf("\n#### diagnostics: %s (d=%d, full=%s)\n", objname, d, full))
+
+  # FAST pass: references + fast BASS variants.
+  set_bass_mcmc(mcmc_presets$fast)
+  ms_fast <- list(
+    list(kind = "random", label = "Random"),
+    list(kind = "gp",     label = "GP-BO"),
+    list(kind = "bass", acq = "ei",       label = "BASS-EI (fast)")
+  )
+  if (full) ms_fast <- c(ms_fast, list(list(kind = "bass", acq = "thompson", label = "BASS-TS (fast)")))
+  rows_fast <- furrr::future_map_dfr(
+    seeds, ~ run_seed_methods(.x, objname, d, DIAG_BUDGET, ms_fast,
+                              cfg0$n_cand, cfg0$eps, cfg0$dup_tol),
+    .options = fopts)
+
+  # RICH pass: rich BASS variants only (references already captured).
+  set_bass_mcmc(mcmc_presets$rich)
+  ms_rich <- list(list(kind = "bass", acq = "ei", label = "BASS-EI (rich)"))
+  if (full) ms_rich <- c(ms_rich, list(list(kind = "bass", acq = "thompson", label = "BASS-TS (rich)")))
+  rows_rich <- furrr::future_map_dfr(
+    seeds, ~ run_seed_methods(.x, objname, d, DIAG_BUDGET, ms_rich,
+                              cfg0$n_cand, cfg0$eps, cfg0$dup_tol),
+    .options = fopts)
+
+  dplyr::bind_rows(rows_fast, rows_rich)
+}
+
+all_runs <- dplyr::bind_rows(lapply(specs, function(s)
+  tryCatch(run_objective(s),
+           error = function(e) { cat("ERROR on", s$name, ":", conditionMessage(e), "\n"); NULL })))
+
+readr::write_csv(all_runs, file.path(OUT, "diag_all_runs.csv"))
+
+# Final-performance leaderboard at budget 80 and at the full diagnostic budget.
+points <- sort(unique(c(min(80L, DIAG_BUDGET), DIAG_BUDGET)))
+final <- all_runs |>
+  dplyr::filter(iter %in% points) |>
+  dplyr::group_by(objective, budget = iter, method) |>
+  dplyr::summarise(mean_final = mean(best), sd_final = sd(best), n = dplyr::n(), .groups = "drop") |>
+  dplyr::arrange(objective, budget, mean_final)
+readr::write_csv(final, file.path(OUT, "diag_final_summary.csv"))
+
+# Convergence curves (mean +/- 95% CI) for later plotting.
+curve <- all_runs |>
+  dplyr::group_by(objective, method, iter) |>
+  dplyr::summarise(mean_best = mean(best), sd_best = sd(best), n = dplyr::n(), .groups = "drop") |>
+  dplyr::mutate(se = sd_best / sqrt(n), ci_low = mean_best - 1.96 * se, ci_high = mean_best + 1.96 * se)
+readr::write_csv(curve, file.path(OUT, "diag_summary_curve.csv"))
+
+# One convergence plot per objective.
+for (o in unique(curve$objective)) {
+  p <- ggplot2::ggplot(dplyr::filter(curve, objective == o),
+                       ggplot2::aes(iter, mean_best, color = method, fill = method)) +
+    ggplot2::geom_ribbon(ggplot2::aes(ymin = ci_low, ymax = ci_high), alpha = 0.12, linewidth = 0) +
+    ggplot2::geom_line(linewidth = 0.9) +
+    ggplot2::labs(title = sprintf("BASS diagnostics: %s", o),
+                  x = "Iteration", y = "Best so far (lower is better)") +
+    ggplot2::theme_minimal()
+  ggplot2::ggsave(file.path(OUT, sprintf("diag_convergence_%s.png", o)),
+                  p, width = 9, height = 5, dpi = 150)
+}
+
+cat("\n==== Diagnostics final summary ====\n")
+print(final, n = 500)
+cat(sprintf("\nDiagnostics written to: %s\n", normalizePath(OUT)))
+plan(sequential)
+R_EOF
+echo "Wrote diagnostics driver: $DRIVER"
+
+# =============================================================================
+# 4. Capture run metadata (hardware, versions, git SHA)
+# =============================================================================
+META="$RESULTS_DIR/run_metadata.txt"
+capture_metadata() {
+  {
+    echo "timestamp:    $(ts)"
+    echo "host:         $(hostname)"
+    echo "uname:        $(uname -a)"
+    echo "nproc:        $(nproc 2>/dev/null)"
+    echo "git_head:     $(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null)"
+    echo "git_branch:   $(git -C "$REPO_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+    echo "RETICULATE_PYTHON: ${RETICULATE_PYTHON:-<unset>}"
+    echo "protocol:     REPS=$REPS BUDGET=$BUDGET | DIAG_REPS=$DIAG_REPS DIAG_BUDGET=$DIAG_BUDGET"
+    echo "rich_mcmc:    nmcmc=$DIAG_RICH_NMCMC nburn=$DIAG_RICH_NBURN thin=$DIAG_RICH_THIN"
+    echo ""
+    echo "--- CPU ---";    (lscpu 2>/dev/null | grep -E 'Model name|^CPU\(s\)|Thread|Core') || true
+    echo "--- Memory ---"; (free -h 2>/dev/null || grep MemTotal /proc/meminfo) || true
+    echo ""
+    echo "--- R + packages ---"
+    Rscript -e 'cat("R", as.character(getRversion()), "\n"); for (p in c("tidyverse","lhs","BASS","GPfit","future","furrr","glmnet","reticulate")) cat(sprintf("  %-12s %s\n", p, tryCatch(as.character(packageVersion(p)), error=function(e) "MISSING")))' 2>/dev/null || true
+    echo "--- optuna ---"
+    [ -n "${RETICULATE_PYTHON:-}" ] && "$RETICULATE_PYTHON" -c "import optuna; print('  optuna', optuna.__version__)" 2>/dev/null || echo "  (optuna not resolved)"
+  } > "$META"
+  cat "$META"
+}
+run_step "metadata" capture_metadata
+
+# =============================================================================
+# 5. Full thesis benchmark suite (each objective isolated, failures non-fatal)
+# =============================================================================
+run_suite() {
+  cd "$CODE_DIR" || return 1
+  # Continuous benchmarks.
+  run_step "bench-branin"    Rscript run_benchmark.R --objective=branin    --d=2 --budget="$BUDGET" --reps="$REPS"
+  run_step "bench-rastrigin" Rscript run_benchmark.R --objective=rastrigin  --d=4 --budget="$BUDGET" --reps="$REPS"
+  run_step "bench-synthetic" Rscript run_benchmark.R --objective=synthetic  --d=3 --budget="$BUDGET" --reps="$REPS"
+  # Categorical / mixed benchmarks (TPE is the strongest comparison here).
+  run_step "bench-func2C"     Rscript run_benchmark.R --objective=func2C            --budget="$BUDGET" --reps="$REPS" --with_tpe="$WITH_TPE"
+  run_step "bench-func3C"     Rscript run_benchmark.R --objective=func3C            --budget="$BUDGET" --reps="$REPS" --with_tpe="$WITH_TPE"
+  run_step "bench-cat_ackley" Rscript run_benchmark.R --objective=cat_ackley --d=6 --budget="$BUDGET" --reps="$REPS" --with_tpe="$WITH_TPE"
+  # TPE gamma-sensitivity ablation (Branin + Cat-Ackley).
+  run_step "tpe-sensitivity"  Rscript 2_tpe_sensitivity/run_tpe_sensitivity.R --budget="$BUDGET" --reps="$REPS"
+  # Elastic Net case study.
+  run_step "elastic-net"      Rscript 4_regression_test_case/run_elastic_net.R --reps="$ENET_REPS" --budget="$ENET_BUDGET"
+}
+[ "$RUN_SUITE" = "1" ] && run_suite
+
+# =============================================================================
+# 6. BASS-trailing investigation
+# =============================================================================
+run_diag() {
+  cd "$CODE_DIR" || return 1
+  Rscript run_bass_diagnostics.R \
+    --reps="$DIAG_REPS" --budget="$DIAG_BUDGET" --out_dir="results/diagnostics"
+}
+[ "$RUN_DIAG" = "1" ] && run_step "bass-diagnostics" run_diag
+
+# =============================================================================
+# 7. Package everything for download
+# =============================================================================
+package_results() {
+  cp -f "$LOG" "$RESULTS_DIR/run.log" 2>/dev/null || true
+  cp -f "$STEPLOG" "$RESULTS_DIR/steps.tsv" 2>/dev/null || true
+  local stamp; stamp="$(date +%Y%m%d_%H%M%S)"
+  local tarball="$WORKDIR/bass_results_${stamp}.tar.gz"
+  tar -czf "$tarball" -C "$CODE_DIR" results
+  echo ""
+  echo "######################################################################"
+  echo "ALL DONE."
+  echo "Results tree : $RESULTS_DIR"
+  echo "Tarball      : $tarball  ($(du -h "$tarball" | cut -f1))"
+  echo ""
+  echo "Step outcomes:"; column -t -s $'\t' "$STEPLOG" 2>/dev/null || cat "$STEPLOG"
+  echo ""
+  echo "Download it from your laptop with, e.g.:"
+  echo "  scp ubuntu@<this-ec2-host>:$tarball ."
+  echo "or push to S3 (if the instance has a role/creds):"
+  echo "  aws s3 cp $tarball s3://<your-bucket>/"
+  echo "######################################################################"
+}
+run_step "package" package_results
+
+log "Finished."


### PR DESCRIPTION
## Why

Random Search was matching or beating BASS-BO on the categorical/mixed benchmarks. A full audit plus a three-part diagnostic (included in this PR under `code_files/3_categorical_diagnostics/`) traced that to problems in the **shared loop machinery and the benchmark protocol**, not in the surrogate or the acquisition:

1. **The local candidate move always flipped ≥1 categorical coordinate**, so no candidate ever refined the continuous coordinates at the best-known categorical combination — exactly the local-exploitation edge BO has over Random on func2C/func3C. Oracle A/B runs (acquisition replaced by the true objective, upper-bounding *any* surrogate) showed a keep-combo generator winning **15/15 paired seeds** on both benchmarks and reaching the func2C optimum (−0.206) within ~10 evaluations where the always-flip pool plateaued at −0.148.
2. **Duplicate detection compared raw [0,1] encodings**, so the loop re-evaluated already-measured level combinations: instrumented easy-mode Cat-Ackley runs lost **25–29 of 40 picks** to revisits.
3. **The only pure-categorical benchmark (Cat-Ackley d=6, L=11 ≈ 1.77M combinations) is uninformative at budget 80**: BASS's held-out rank correlation reaches only ~0.47 by n=73. Meanwhile an easy instance (5³ = 125) shows BASS-BO finding the exact optimum **10/10 seeds vs Random's 5/10** — the capability is real, the instance was just unsolvable.
4. **The experiment is paired by construction** (shared initial design per seed) but summaries reported only unpaired means ± SD of skewed minima.

## What changed

- `local_categorical_moves()`: each categorical coordinate flips independently w.p. 1/n_cat (derived, not tuned); mixed schemas can keep the full incumbent combination, purely categorical schemas still force ≥1 flip.
- `canonicalize()` + loop dedup: duplicates are judged on decoded combinations for every method (model-based masking and Random's redraw), with a bounded retry so tiny exhausted spaces can't spin.
- Loop/surrogate hygiene: random tie-breaking for the acquisition argmax (flat-EI ties were biased to the pool's first row), a guard for the `predict()` orientation ambiguity at `n_cand == 200`, and a visible message when the GP fit-failure fallback fires.
- `--cat_L` protocol knob: Cat-Ackley now benchmarked at easy (5³) / medium (7⁴) / hard (11⁶) sizes, with size-stamped result folders; default L=11 preserves the classic instance.
- `summarise_paired()`: per-seed win/tie/loss vs Random + paired Wilcoxon signed-rank, written as `paired_vs_random.csv` and printed by the runner.
- Diagnostics folder documenting the method and the pre-fix findings, re-usable as a regression harness; also integrates the EC2 runner from `claude/categorical-candidates` (now pointed at this branch) so this PR carries everything unmerged.

The thesis's core design is untouched: one loop, one acquisition, shared candidates — the surrogate remains the only difference between BASS-BO and GP-BO, and all fixes apply to both symmetrically.

## Validation

- Test suite: **88 pass, 0 fail** (8 environment skips: BASS/optuna), including new tests for keep-combo moves, canonicalization, no-revisit guarantees, `cat_L` wiring, and paired summaries.
- Post-fix oracle regression: both generator arms now reach the func2C/func3C optima within ~12 evaluations (pre-fix gap eliminated).
- Recommended before merge: rerun `code_files/3_categorical_diagnostics/run_diagnostics.R --reps=10 --budget=60` with BASS installed — expect revisit counts ≈ 0, func2C paired wins flipped in BASS-BO's favour, easy-mode still 10/10 — then `run_all_final.sh` (or `run_on_ec2.sh`) for the thesis-facing numbers.